### PR TITLE
ci: harden workflows to match kafka-backup gold standard

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Get version from Cargo.toml
         id: version
@@ -43,13 +45,13 @@ jobs:
           echo "Detected version: $VERSION"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -65,8 +67,23 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - name: Build Docker image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test - verify binary is linked and executable
+        run: |
+          docker run --rm --entrypoint ldd ${{ env.IMAGE_NAME }}:test --version
+          docker run --rm --entrypoint ls ${{ env.IMAGE_NAME }}:test -la /usr/local/bin/kafka-backup-operator
+          echo "Docker smoke test passed!"
+
+      - name: Push Docker image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
@@ -42,15 +44,20 @@ jobs:
           echo "Version verified: $CARGO_VERSION"
 
   test:
-    name: Run Tests
+    name: Pre-release Tests
     runs-on: ubuntu-latest
     needs: validate
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -59,13 +66,20 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-test-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
         run: cargo test --all-features
-
-      - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+        env:
+          RUST_LOG: debug
 
   build-and-push:
     name: Build and Push Docker Image
@@ -74,15 +88,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -90,7 +106,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -99,8 +115,23 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - name: Build Docker image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test - verify binary is linked and executable
+        run: |
+          docker run --rm --entrypoint ldd ${{ env.IMAGE_NAME }}:test --version
+          docker run --rm --entrypoint ls ${{ env.IMAGE_NAME }}:test -la /usr/local/bin/kafka-backup-operator
+          echo "Docker smoke test passed!"
+
+      - name: Push Docker image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -118,10 +149,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -130,7 +165,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate CRDs
         run: cargo run --release --bin crdgen
@@ -144,65 +179,61 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          # Get the previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          TAG="${GITHUB_REF#refs/tags/}"
 
-          if [ -z "$PREV_TAG" ]; then
-            echo "First release - no previous tag found"
-            COMMITS=$(git log --pretty=format:"- %s" HEAD)
-          else
-            echo "Previous tag: $PREV_TAG"
-            COMMITS=$(git log --pretty=format:"- %s" ${PREV_TAG}..HEAD)
+          # Find the previous tag for changelog generation
+          PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^${TAG}$" | tail -1)
+          if [ "$PREV_TAG" = "$TAG" ] || [ -z "$PREV_TAG" ]; then
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD | head -1)
+          fi
+          echo "Generating changelog: ${PREV_TAG}..${TAG}"
+
+          # Generate changelog grouped by conventional commit type
+          echo "## What's Changed" > changelog.md
+          echo "" >> changelog.md
+
+          FEATURES=$(git log "${PREV_TAG}..${TAG}" --oneline --grep="^feat" --format="* %s" 2>/dev/null | head -20)
+          if [ -n "$FEATURES" ]; then
+            echo "### Features" >> changelog.md
+            echo "$FEATURES" >> changelog.md
+            echo "" >> changelog.md
           fi
 
-          # Write changelog to file (handles multi-line)
-          echo "$COMMITS" > changelog.txt
+          FIXES=$(git log "${PREV_TAG}..${TAG}" --oneline --grep="^fix" --format="* %s" 2>/dev/null | head -20)
+          if [ -n "$FIXES" ]; then
+            echo "### Fixes" >> changelog.md
+            echo "$FIXES" >> changelog.md
+            echo "" >> changelog.md
+          fi
+
+          DEPS=$(git log "${PREV_TAG}..${TAG}" --oneline --grep="^deps\|^dep\|^chore(deps)\|Bump" --format="* %s" 2>/dev/null | head -20)
+          if [ -n "$DEPS" ]; then
+            echo "### Dependencies" >> changelog.md
+            echo "$DEPS" >> changelog.md
+            echo "" >> changelog.md
+          fi
+
+          OTHER=$(git log "${PREV_TAG}..${TAG}" --oneline --grep="^ci\|^chore\|^style\|^refactor" --format="* %s" 2>/dev/null | head -20)
+          if [ -n "$OTHER" ]; then
+            echo "### Other" >> changelog.md
+            echo "$OTHER" >> changelog.md
+            echo "" >> changelog.md
+          fi
+
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}" >> changelog.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: v${{ needs.validate.outputs.version }}
-          body: |
-            ## Kafka Backup Operator for Strimzi v${{ needs.validate.outputs.version }}
-
-            ### Docker Images
-
-            ```bash
-            docker pull ghcr.io/osodevops/kafka-backup-operator:${{ needs.validate.outputs.version }}
-            ```
-
-            ### Installation
-
-            ```bash
-            # Add the Helm repository
-            helm repo add oso-devops https://osodevops.github.io/helm-charts/
-            helm repo update
-
-            # Install the operator
-            helm install kafka-backup-operator oso-devops/kafka-backup-operator \
-              --namespace kafka \
-              --create-namespace \
-              --version ${{ needs.validate.outputs.version }}
-            ```
-
-            ### Changes
-
-            ${{ steps.changelog.outputs.commits }}
-
-            ### CRDs
-
-            The Custom Resource Definitions are attached to this release. Apply them with:
-
-            ```bash
-            kubectl apply -f crds.yaml
-            ```
+          body_path: changelog.md
           files: |
             crds.yaml
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
-          generate_release_notes: true
+          generate_release_notes: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
   sync-helm-chart:
     name: Trigger Helm Chart Sync
@@ -216,4 +247,3 @@ jobs:
           repository: osodevops/helm-charts
           event-type: update-kafka-backup-operator
           client-payload: '{"version": "${{ needs.validate.outputs.version }}"}'
-        continue-on-error: true

--- a/.github/workflows/sync-helm-chart.yaml
+++ b/.github/workflows/sync-helm-chart.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout source repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           path: source-repo
 
       - name: Get chart version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,30 +1,79 @@
-name: Test
+name: Tests
 
 permissions:
   contents: read
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.github/workflows/**'
   pull_request:
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.github/workflows/**'
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
-    name: Test Suite
+  check:
+    name: Check & Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-check-
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Check compilation
+        run: cargo check --all-targets
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -40,58 +89,72 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features --verbose
+        env:
+          RUST_LOG: debug
 
-  clippy:
-    name: Clippy
+  security-audit:
+    name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
-          components: clippy
+          toolchain: stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
-            ${{ runner.os }}-cargo-
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
 
-      - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+      - name: Run security audit
+        run: cargo audit
+        continue-on-error: true
 
-  fmt:
-    name: Format
+  docker-build:
+    name: Docker Build & Smoke Test
     runs-on: ubuntu-latest
+    needs: check
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          components: rustfmt
+          persist-credentials: false
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          load: true
+          tags: kafka-backup-operator:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test - verify binary is linked and executable
+        run: |
+          echo "Verifying glibc version in runtime image..."
+          docker run --rm --entrypoint ldd kafka-backup-operator:test --version
+          echo ""
+          echo "Verifying binary exists and is executable..."
+          docker run --rm --entrypoint ls kafka-backup-operator:test -la /usr/local/bin/kafka-backup-operator
+          echo "Docker smoke test passed!"
 
   build:
-    name: Build
+    name: Build Release & Generate CRDs
     runs-on: ubuntu-latest
+    needs: check
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -113,3 +176,20 @@ jobs:
 
       - name: Verify CRDs are up to date
         run: git diff --exit-code deploy/crds/
+
+  tests-complete:
+    name: Tests Complete
+    runs-on: ubuntu-latest
+    needs: [check, test, docker-build, build]
+    if: always()
+    steps:
+      - name: Check all tests passed
+        run: |
+          if [ "${{ needs.check.result }}" != "success" ] || \
+             [ "${{ needs.test.result }}" != "success" ] || \
+             [ "${{ needs.docker-build.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi
+          echo "All required tests passed!"

--- a/src/adapters/storage_config.rs
+++ b/src/adapters/storage_config.rs
@@ -183,15 +183,15 @@ mod tests {
         let config = build_storage_config(&storage).unwrap();
         let mapping = config.as_mapping().unwrap();
         assert_eq!(
-            mapping.get(&Value::String("type".to_string())),
+            mapping.get(Value::String("type".to_string())),
             Some(&Value::String("s3".to_string()))
         );
         assert_eq!(
-            mapping.get(&Value::String("bucket".to_string())),
+            mapping.get(Value::String("bucket".to_string())),
             Some(&Value::String("my-bucket".to_string()))
         );
         assert_eq!(
-            mapping.get(&Value::String("region".to_string())),
+            mapping.get(Value::String("region".to_string())),
             Some(&Value::String("us-east-1".to_string()))
         );
     }

--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -240,7 +240,7 @@ mod tests {
         let state = MetricsState::new();
         let output = state.gather();
         // Should contain metric definitions even without data
-        assert!(output.is_empty() || output.contains("strimzi_backup") || output.len() >= 0);
+        assert!(output.is_empty() || output.contains("strimzi_backup"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Aligns all CI/CD workflows with the security patterns established across the osodevops Kafka ecosystem after the supply chain attack attempt on kafka-backup-operator (PR osodevops/kafka-backup-operator#26).

## Changes

### All workflows
- `persist-credentials: false` on all checkout steps (11/12 — target repo checkout in sync-helm-chart correctly retains credentials)
- Docker actions upgraded: v3→v4 (login, setup-buildx, setup-qemu), v5→v6 (metadata), v6→v7 (build-push)
- All actions pinned to immutable commit SHAs (verified against kafka-backup repo)
- All 4 workflows have explicit `permissions:` blocks

### test.yaml
- Restructured with job dependencies: `check` → `test`, `docker-build`, `build` → `tests-complete` gate
- Added `security-audit` job with `cargo audit`
- Added `docker-build` smoke test (ldd + ls verify binary)
- Added path filtering (only runs on relevant file changes)
- Combined fmt+clippy into single `check` job

### docker-publish.yaml
- Two-phase build: `load: true` → smoke test → `push: true`

### release.yaml
- Docker smoke test before push
- Conventional commit changelog (feat/fix/deps/other grouping)
- `fetch-tags: true` for proper changelog generation
- `RELEASE_PAT` for release creation
- Removed `continue-on-error` on helm sync

## Test plan

- [x] Zero unpinned actions (`grep` verified)
- [x] All action SHAs match kafka-backup-operator gold standard
- [x] 11/12 checkouts have `persist-credentials: false` (1 correctly excluded)
- [x] All 4 workflows have `permissions:` blocks
- [ ] CI runs and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)