### PR TITLE
fix: align CRDs with kafka-backup core config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,18 @@ spec:
     s3:
       bucket: my-kafka-backups
       region: eu-west-1
-      credentialsSecret:
+      accessKeySecret:
         name: aws-credentials
-        key: credentials
+        key: access-key-id
+      secretKeySecret:
+        name: aws-credentials
+        key: secret-access-key
   topics:
     include:
-      - "orders.*"
-      - "payments.*"
+      - "orders-*"
+      - "payments-*"
     exclude:
-      - "__.*"
+      - "__*"
   backup:
     compression: zstd
     parallelism: 4
@@ -163,9 +166,12 @@ storage:
     bucket: my-kafka-backups
     region: eu-west-1
     prefix: production/
-    credentialsSecret:
+    accessKeySecret:
       name: aws-credentials
-      key: credentials
+      key: access-key-id
+    secretKeySecret:
+      name: aws-credentials
+      key: secret-access-key
 ```
 
 ### Azure Blob Storage
@@ -177,9 +183,9 @@ storage:
     storageAccount: myaccount
     container: kafka-backups
     prefix: production/
-    credentialsSecret:
+    accountKeySecret:
       name: azure-credentials
-      key: connection-string
+      key: account-key
 ```
 
 ### Google Cloud Storage
@@ -204,9 +210,13 @@ storage:
     bucket: kafka-backups
     endpoint: https://minio.example.com
     forcePathStyle: true
-    credentialsSecret:
+    allowHttp: false
+    accessKeySecret:
       name: minio-credentials
-      key: credentials
+      key: access-key-id
+    secretKeySecret:
+      name: minio-credentials
+      key: secret-access-key
 ```
 
 ## Authentication

--- a/config/examples/kafka-backup-s3.yaml
+++ b/config/examples/kafka-backup-s3.yaml
@@ -16,11 +16,11 @@ spec:
 
   topics:
     include:
-      - "orders.*"
-      - "payments.*"
+      - "orders-*"
+      - "payments-*"
     exclude:
-      - ".*\\.internal"
-      - "__.*"
+      - "*-internal"
+      - "__*"
 
   storage:
     type: s3
@@ -28,14 +28,18 @@ spec:
       bucket: my-kafka-backups
       region: eu-west-1
       prefix: "strimzi/my-kafka-cluster/"
-      credentialsSecret:
+      accessKeySecret:
         name: backup-s3-credentials
-        key: aws-credentials
+        key: access-key-id
+      secretKeySecret:
+        name: backup-s3-credentials
+        key: secret-access-key
 
   backup:
     compression: zstd
     segmentSize: 268435456
     parallelism: 4
+    stopAtCurrentOffsets: true
 
   schedule:
     cron: "0 2 * * *"

--- a/config/examples/kafka-restore-pitr.yaml
+++ b/config/examples/kafka-restore-pitr.yaml
@@ -35,7 +35,7 @@ spec:
 
   restore:
     topicCreation: auto
-    existingTopicPolicy: fail
+    existingTopicPolicy: append
     parallelism: 4
 
   resources:

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -100,10 +100,29 @@ spec:
                 description: Backup options (compression, encryption, parallelism)
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   compression:
-                    description: 'Compression algorithm: none, gzip, snappy, lz4, zstd'
+                    description: 'Compression algorithm: none, lz4, zstd'
                     nullable: true
                     type: string
+                  compressionLevel:
+                    description: 'Compression level (zstd: 1-22)'
+                    format: int32
+                    nullable: true
+                    type: integer
+                  consumerGroupSnapshot:
+                    description: Snapshot consumer group offsets after each backup cycle
+                    nullable: true
+                    type: boolean
+                  continuous:
+                    description: Run continuously instead of one-shot
+                    nullable: true
+                    type: boolean
                   encryption:
                     description: Encryption configuration
                     nullable: true
@@ -127,9 +146,34 @@ spec:
                         - name
                         type: object
                     type: object
+                  includeInternalTopics:
+                    description: Include internal Kafka topics
+                    nullable: true
+                    type: boolean
+                  includeOffsetHeaders:
+                    description: Include original Kafka offset headers in backup records
+                    nullable: true
+                    type: boolean
+                  internalTopics:
+                    description: Internal topics to include
+                    items:
+                      type: string
+                    type: array
                   parallelism:
                     description: 'Number of concurrent partition backup threads (default: 4)'
                     format: int32
+                    nullable: true
+                    type: integer
+                  pollIntervalMs:
+                    description: Continuous-mode poll interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  segmentMaxIntervalMs:
+                    description: Maximum segment time interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
                     nullable: true
                     type: integer
                   segmentSize:
@@ -137,6 +181,55 @@ spec:
                     format: int64
                     nullable: true
                     type: integer
+                  sourceClusterId:
+                    description: Source cluster identifier written to record headers
+                    nullable: true
+                    type: string
+                  startOffset:
+                    description: 'Starting offset for backups: earliest or latest'
+                    nullable: true
+                    type: string
+                  stopAtCurrentOffsets:
+                    description: Snapshot current high watermarks and exit when caught up
+                    nullable: true
+                    type: boolean
+                  syncIntervalSecs:
+                    description: Remote offset database sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              connection:
+                description: Kafka connection tuning for the source cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
                 type: object
               consumerGroups:
                 description: Consumer group selection
@@ -157,6 +250,64 @@ spec:
                 description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for backup job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              offsetStorage:
+                description: Offset storage configuration for continuous backup progress
+                nullable: true
+                properties:
+                  backend:
+                    description: 'Offset storage backend: sqlite or memory'
+                    nullable: true
+                    type: string
+                  dbPath:
+                    description: Path to the local SQLite database file
+                    nullable: true
+                    type: string
+                  s3Key:
+                    description: Remote S3 key used to sync the offset database
+                    nullable: true
+                    type: string
+                  syncIntervalSecs:
+                    description: Remote sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               resources:
                 description: Resource requirements for backup pods
                 nullable: true
@@ -215,6 +366,38 @@ spec:
                     description: Azure Blob Storage configuration
                     nullable: true
                     properties:
+                      accountKeySecret:
+                        description: Storage account key secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      clientId:
+                        description: Azure AD client ID
+                        nullable: true
+                        type: string
+                      clientSecretSecret:
+                        description: Service principal client secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       container:
                         description: Azure blob container name
                         type: string
@@ -232,16 +415,52 @@ spec:
                         - key
                         - name
                         type: object
+                      endpoint:
+                        description: Custom endpoint for sovereign clouds
+                        nullable: true
+                        type: string
                       prefix:
                         description: Key prefix within the container
                         nullable: true
                         type: string
+                      sasTokenSecret:
+                        description: SAS token secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       storageAccount:
                         description: Azure storage account name
                         type: string
+                      tenantId:
+                        description: Azure AD tenant ID
+                        nullable: true
+                        type: string
+                      useWorkloadIdentity:
+                        description: Enable Azure Workload Identity
+                        nullable: true
+                        type: boolean
                     required:
                     - container
                     - storageAccount
+                    type: object
+                  filesystem:
+                    description: Filesystem storage configuration
+                    nullable: true
+                    properties:
+                      path:
+                        description: Base path for backup data
+                        type: string
+                    required:
+                    - path
                     type: object
                   gcs:
                     description: Google Cloud Storage configuration
@@ -268,6 +487,10 @@ spec:
                         description: Key prefix within the bucket
                         nullable: true
                         type: string
+                      serviceAccountPath:
+                        description: Path to a mounted service account JSON file
+                        nullable: true
+                        type: string
                     required:
                     - bucket
                     type: object
@@ -275,6 +498,24 @@ spec:
                     description: S3-compatible storage configuration
                     nullable: true
                     properties:
+                      accessKeySecret:
+                        description: Secret key containing AWS access key ID
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      allowHttp:
+                        description: Allow insecure HTTP connections
+                        nullable: true
+                        type: boolean
                       bucket:
                         description: S3 bucket name
                         type: string
@@ -308,6 +549,20 @@ spec:
                         description: AWS region
                         nullable: true
                         type: string
+                      secretKeySecret:
+                        description: Secret key containing AWS secret access key
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                     required:
                     - bucket
                     type: object
@@ -317,6 +572,7 @@ spec:
                     - s3
                     - azure
                     - gcs
+                    - filesystem
                     type: string
                 required:
                 - type
@@ -400,16 +656,16 @@ spec:
                     type: object
                 type: object
               topics:
-                description: Topic selection with include/exclude regex patterns
+                description: Topic selection with include/exclude glob patterns
                 nullable: true
                 properties:
                   exclude:
-                    description: Regex patterns for topics to exclude
+                    description: Glob patterns for topics to exclude
                     items:
                       type: string
                     type: array
                   include:
-                    description: Regex patterns for topics to include
+                    description: Glob patterns for topics to include
                     items:
                       type: string
                     type: array

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -106,10 +106,50 @@ spec:
                 required:
                 - name
                 type: object
+              connection:
+                description: Kafka connection tuning for the target cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
+                type: object
               consumerGroups:
                 description: Consumer group restore configuration
                 nullable: true
                 properties:
+                  auto:
+                    description: Automatically load the consumer group snapshot from backup storage
+                    nullable: true
+                    type: boolean
+                  groups:
+                    description: Consumer groups to reset
+                    items:
+                      type: string
+                    type: array
                   mapping:
                     description: Consumer group mappings (source → target)
                     items:
@@ -126,21 +166,68 @@ spec:
                       - targetGroup
                       type: object
                     type: array
+                  offsetReport:
+                    description: Output file path for offset mapping report
+                    nullable: true
+                    type: string
                   restore:
                     default: false
                     description: Whether to restore consumer group offsets
                     type: boolean
+                  strategy:
+                    description: 'Offset handling strategy: skip, header-based, timestamp-based, cluster-scan, manual'
+                    nullable: true
+                    type: string
                 type: object
               image:
                 description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for restore job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               pointInTime:
                 description: Point-in-time recovery settings
                 nullable: true
                 properties:
                   offsetFromEnd:
-                    description: Duration offset from backup end (e.g., "2h", "30m")
+                    description: Duration offset from backup end (not supported by the current kafka-backup core)
+                    nullable: true
+                    type: string
+                  startTimestamp:
+                    description: Start timestamp for the restore window (ISO 8601 with millisecond precision)
                     nullable: true
                     type: string
                   timestamp:
@@ -167,19 +254,119 @@ spec:
                 description: Restore behaviour options
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  checkpointState:
+                    description: Checkpoint state file path
+                    nullable: true
+                    type: string
+                  defaultReplicationFactor:
+                    description: Replication factor for auto-created topics
+                    format: int16
+                    nullable: true
+                    type: integer
+                  dryRun:
+                    description: 'Dry-run mode: validate without writing records'
+                    nullable: true
+                    type: boolean
                   existingTopicPolicy:
-                    description: 'Policy for existing topics: fail, append, or overwrite'
+                    description: 'Policy for existing topics: append or overwrite. fail is accepted for legacy CRs but rejected at runtime.'
                     enum:
                     - fail
                     - append
                     - overwrite
                     nullable: true
                     type: string
+                  includeOriginalOffsetHeader:
+                    description: Include original offsets as headers on restored records
+                    nullable: true
+                    type: boolean
                   parallelism:
                     description: 'Number of concurrent restore threads (default: 4)'
                     format: int32
                     nullable: true
                     type: integer
+                  partitionMapping:
+                    description: Partition mapping entries
+                    items:
+                      description: Mapping for source partition to target partition.
+                      properties:
+                        sourcePartition:
+                          description: Source partition number
+                          format: int32
+                          type: integer
+                        targetPartition:
+                          description: Target partition number
+                          format: int32
+                          type: integer
+                      required:
+                      - sourcePartition
+                      - targetPartition
+                      type: object
+                    type: array
+                  produceAcks:
+                    description: Producer acks setting (-1, 0, or 1)
+                    format: int16
+                    nullable: true
+                    type: integer
+                  produceBatchSize:
+                    description: Produce batch size
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  produceTimeoutMs:
+                    description: Broker-side produce timeout in milliseconds
+                    format: int32
+                    nullable: true
+                    type: integer
+                  purgeTopics:
+                    description: Purge target topics before restoring
+                    nullable: true
+                    type: boolean
+                  rateLimitBytesPerSec:
+                    description: Rate limit in bytes per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  rateLimitRecordsPerSec:
+                    description: Rate limit in records per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  repartitioning:
+                    description: Per-topic repartitioning configuration
+                    items:
+                      description: Per-topic repartitioning configuration keyed by target topic name.
+                      properties:
+                        strategy:
+                          description: 'Partitioning strategy: murmur2 or automatic'
+                          nullable: true
+                          type: string
+                        targetPartitions:
+                          description: Target partition count
+                          format: int32
+                          type: integer
+                        topic:
+                          description: Target topic name
+                          type: string
+                      required:
+                      - targetPartitions
+                      - topic
+                      type: object
+                    type: array
+                  sourcePartitions:
+                    description: Source partitions to restore
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   topicCreation:
                     description: 'Topic creation strategy: auto or manual'
                     enum:

--- a/deploy/helm/kafka-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/kafka-backup-operator/crds/kafkabackups.yaml
@@ -100,10 +100,29 @@ spec:
                 description: Backup options (compression, encryption, parallelism)
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   compression:
-                    description: 'Compression algorithm: none, gzip, snappy, lz4, zstd'
+                    description: 'Compression algorithm: none, lz4, zstd'
                     nullable: true
                     type: string
+                  compressionLevel:
+                    description: 'Compression level (zstd: 1-22)'
+                    format: int32
+                    nullable: true
+                    type: integer
+                  consumerGroupSnapshot:
+                    description: Snapshot consumer group offsets after each backup cycle
+                    nullable: true
+                    type: boolean
+                  continuous:
+                    description: Run continuously instead of one-shot
+                    nullable: true
+                    type: boolean
                   encryption:
                     description: Encryption configuration
                     nullable: true
@@ -127,9 +146,34 @@ spec:
                         - name
                         type: object
                     type: object
+                  includeInternalTopics:
+                    description: Include internal Kafka topics
+                    nullable: true
+                    type: boolean
+                  includeOffsetHeaders:
+                    description: Include original Kafka offset headers in backup records
+                    nullable: true
+                    type: boolean
+                  internalTopics:
+                    description: Internal topics to include
+                    items:
+                      type: string
+                    type: array
                   parallelism:
                     description: 'Number of concurrent partition backup threads (default: 4)'
                     format: int32
+                    nullable: true
+                    type: integer
+                  pollIntervalMs:
+                    description: Continuous-mode poll interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  segmentMaxIntervalMs:
+                    description: Maximum segment time interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
                     nullable: true
                     type: integer
                   segmentSize:
@@ -137,6 +181,55 @@ spec:
                     format: int64
                     nullable: true
                     type: integer
+                  sourceClusterId:
+                    description: Source cluster identifier written to record headers
+                    nullable: true
+                    type: string
+                  startOffset:
+                    description: 'Starting offset for backups: earliest or latest'
+                    nullable: true
+                    type: string
+                  stopAtCurrentOffsets:
+                    description: Snapshot current high watermarks and exit when caught up
+                    nullable: true
+                    type: boolean
+                  syncIntervalSecs:
+                    description: Remote offset database sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              connection:
+                description: Kafka connection tuning for the source cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
                 type: object
               consumerGroups:
                 description: Consumer group selection
@@ -157,6 +250,64 @@ spec:
                 description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for backup job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              offsetStorage:
+                description: Offset storage configuration for continuous backup progress
+                nullable: true
+                properties:
+                  backend:
+                    description: 'Offset storage backend: sqlite or memory'
+                    nullable: true
+                    type: string
+                  dbPath:
+                    description: Path to the local SQLite database file
+                    nullable: true
+                    type: string
+                  s3Key:
+                    description: Remote S3 key used to sync the offset database
+                    nullable: true
+                    type: string
+                  syncIntervalSecs:
+                    description: Remote sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               resources:
                 description: Resource requirements for backup pods
                 nullable: true
@@ -215,6 +366,38 @@ spec:
                     description: Azure Blob Storage configuration
                     nullable: true
                     properties:
+                      accountKeySecret:
+                        description: Storage account key secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      clientId:
+                        description: Azure AD client ID
+                        nullable: true
+                        type: string
+                      clientSecretSecret:
+                        description: Service principal client secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       container:
                         description: Azure blob container name
                         type: string
@@ -232,16 +415,52 @@ spec:
                         - key
                         - name
                         type: object
+                      endpoint:
+                        description: Custom endpoint for sovereign clouds
+                        nullable: true
+                        type: string
                       prefix:
                         description: Key prefix within the container
                         nullable: true
                         type: string
+                      sasTokenSecret:
+                        description: SAS token secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       storageAccount:
                         description: Azure storage account name
                         type: string
+                      tenantId:
+                        description: Azure AD tenant ID
+                        nullable: true
+                        type: string
+                      useWorkloadIdentity:
+                        description: Enable Azure Workload Identity
+                        nullable: true
+                        type: boolean
                     required:
                     - container
                     - storageAccount
+                    type: object
+                  filesystem:
+                    description: Filesystem storage configuration
+                    nullable: true
+                    properties:
+                      path:
+                        description: Base path for backup data
+                        type: string
+                    required:
+                    - path
                     type: object
                   gcs:
                     description: Google Cloud Storage configuration
@@ -268,6 +487,10 @@ spec:
                         description: Key prefix within the bucket
                         nullable: true
                         type: string
+                      serviceAccountPath:
+                        description: Path to a mounted service account JSON file
+                        nullable: true
+                        type: string
                     required:
                     - bucket
                     type: object
@@ -275,6 +498,24 @@ spec:
                     description: S3-compatible storage configuration
                     nullable: true
                     properties:
+                      accessKeySecret:
+                        description: Secret key containing AWS access key ID
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      allowHttp:
+                        description: Allow insecure HTTP connections
+                        nullable: true
+                        type: boolean
                       bucket:
                         description: S3 bucket name
                         type: string
@@ -308,6 +549,20 @@ spec:
                         description: AWS region
                         nullable: true
                         type: string
+                      secretKeySecret:
+                        description: Secret key containing AWS secret access key
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                     required:
                     - bucket
                     type: object
@@ -317,6 +572,7 @@ spec:
                     - s3
                     - azure
                     - gcs
+                    - filesystem
                     type: string
                 required:
                 - type
@@ -400,16 +656,16 @@ spec:
                     type: object
                 type: object
               topics:
-                description: Topic selection with include/exclude regex patterns
+                description: Topic selection with include/exclude glob patterns
                 nullable: true
                 properties:
                   exclude:
-                    description: Regex patterns for topics to exclude
+                    description: Glob patterns for topics to exclude
                     items:
                       type: string
                     type: array
                   include:
-                    description: Regex patterns for topics to include
+                    description: Glob patterns for topics to include
                     items:
                       type: string
                     type: array

--- a/deploy/helm/kafka-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/kafka-backup-operator/crds/kafkarestores.yaml
@@ -106,10 +106,50 @@ spec:
                 required:
                 - name
                 type: object
+              connection:
+                description: Kafka connection tuning for the target cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
+                type: object
               consumerGroups:
                 description: Consumer group restore configuration
                 nullable: true
                 properties:
+                  auto:
+                    description: Automatically load the consumer group snapshot from backup storage
+                    nullable: true
+                    type: boolean
+                  groups:
+                    description: Consumer groups to reset
+                    items:
+                      type: string
+                    type: array
                   mapping:
                     description: Consumer group mappings (source → target)
                     items:
@@ -126,21 +166,68 @@ spec:
                       - targetGroup
                       type: object
                     type: array
+                  offsetReport:
+                    description: Output file path for offset mapping report
+                    nullable: true
+                    type: string
                   restore:
                     default: false
                     description: Whether to restore consumer group offsets
                     type: boolean
+                  strategy:
+                    description: 'Offset handling strategy: skip, header-based, timestamp-based, cluster-scan, manual'
+                    nullable: true
+                    type: string
                 type: object
               image:
                 description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for restore job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               pointInTime:
                 description: Point-in-time recovery settings
                 nullable: true
                 properties:
                   offsetFromEnd:
-                    description: Duration offset from backup end (e.g., "2h", "30m")
+                    description: Duration offset from backup end (not supported by the current kafka-backup core)
+                    nullable: true
+                    type: string
+                  startTimestamp:
+                    description: Start timestamp for the restore window (ISO 8601 with millisecond precision)
                     nullable: true
                     type: string
                   timestamp:
@@ -167,19 +254,119 @@ spec:
                 description: Restore behaviour options
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  checkpointState:
+                    description: Checkpoint state file path
+                    nullable: true
+                    type: string
+                  defaultReplicationFactor:
+                    description: Replication factor for auto-created topics
+                    format: int16
+                    nullable: true
+                    type: integer
+                  dryRun:
+                    description: 'Dry-run mode: validate without writing records'
+                    nullable: true
+                    type: boolean
                   existingTopicPolicy:
-                    description: 'Policy for existing topics: fail, append, or overwrite'
+                    description: 'Policy for existing topics: append or overwrite. fail is accepted for legacy CRs but rejected at runtime.'
                     enum:
                     - fail
                     - append
                     - overwrite
                     nullable: true
                     type: string
+                  includeOriginalOffsetHeader:
+                    description: Include original offsets as headers on restored records
+                    nullable: true
+                    type: boolean
                   parallelism:
                     description: 'Number of concurrent restore threads (default: 4)'
                     format: int32
                     nullable: true
                     type: integer
+                  partitionMapping:
+                    description: Partition mapping entries
+                    items:
+                      description: Mapping for source partition to target partition.
+                      properties:
+                        sourcePartition:
+                          description: Source partition number
+                          format: int32
+                          type: integer
+                        targetPartition:
+                          description: Target partition number
+                          format: int32
+                          type: integer
+                      required:
+                      - sourcePartition
+                      - targetPartition
+                      type: object
+                    type: array
+                  produceAcks:
+                    description: Producer acks setting (-1, 0, or 1)
+                    format: int16
+                    nullable: true
+                    type: integer
+                  produceBatchSize:
+                    description: Produce batch size
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  produceTimeoutMs:
+                    description: Broker-side produce timeout in milliseconds
+                    format: int32
+                    nullable: true
+                    type: integer
+                  purgeTopics:
+                    description: Purge target topics before restoring
+                    nullable: true
+                    type: boolean
+                  rateLimitBytesPerSec:
+                    description: Rate limit in bytes per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  rateLimitRecordsPerSec:
+                    description: Rate limit in records per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  repartitioning:
+                    description: Per-topic repartitioning configuration
+                    items:
+                      description: Per-topic repartitioning configuration keyed by target topic name.
+                      properties:
+                        strategy:
+                          description: 'Partitioning strategy: murmur2 or automatic'
+                          nullable: true
+                          type: string
+                        targetPartitions:
+                          description: Target partition count
+                          format: int32
+                          type: integer
+                        topic:
+                          description: Target topic name
+                          type: string
+                      required:
+                      - targetPartitions
+                      - topic
+                      type: object
+                    type: array
+                  sourcePartitions:
+                    description: Source partitions to restore
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   topicCreation:
                     description: 'Topic creation strategy: auto or manual'
                     enum:

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -23,17 +23,20 @@ pub fn build_backup_config_yaml(
         Value::String("backup".to_string()),
     );
 
-    // Backup ID (generated from CR name + timestamp placeholder — actual ID set at runtime)
+    // Backup ID is provided by the job pod via env var so scheduled jobs get unique IDs.
     config.insert(
         Value::String("backup_id".to_string()),
-        Value::String(format!(
-            "{}-{{timestamp}}",
-            backup.metadata.name.as_deref().unwrap_or("backup")
-        )),
+        Value::String("${BACKUP_ID}".to_string()),
     );
 
     // Source (Kafka cluster)
-    let source = build_kafka_config(cluster, tls_certs, auth)?;
+    let source = build_kafka_config(
+        cluster,
+        tls_certs,
+        auth,
+        backup.spec.topics.as_ref(),
+        backup.spec.connection.as_ref(),
+    )?;
     config.insert(Value::String("source".to_string()), source);
 
     // Storage
@@ -46,37 +49,24 @@ pub fn build_backup_config_yaml(
         config.insert(Value::String("backup".to_string()), opts);
     }
 
-    // Topic selection
-    if let Some(topics) = &backup.spec.topics {
-        let mut topic_config = serde_yaml::Mapping::new();
-        if !topics.include.is_empty() {
-            topic_config.insert(
-                Value::String("include".to_string()),
-                Value::Sequence(
-                    topics
-                        .include
-                        .iter()
-                        .map(|s| Value::String(s.clone()))
-                        .collect(),
-                ),
-            );
+    // Metrics options
+    if let Some(metrics) = &backup.spec.metrics {
+        let opts = build_metrics_options(metrics);
+        if let Value::Mapping(ref m) = opts {
+            if !m.is_empty() {
+                config.insert(Value::String("metrics".to_string()), opts);
+            }
         }
-        if !topics.exclude.is_empty() {
-            topic_config.insert(
-                Value::String("exclude".to_string()),
-                Value::Sequence(
-                    topics
-                        .exclude
-                        .iter()
-                        .map(|s| Value::String(s.clone()))
-                        .collect(),
-                ),
-            );
+    }
+
+    // Offset storage
+    if let Some(offset_storage) = &backup.spec.offset_storage {
+        let opts = build_offset_storage_options(offset_storage);
+        if let Value::Mapping(ref m) = opts {
+            if !m.is_empty() {
+                config.insert(Value::String("offset_storage".to_string()), opts);
+            }
         }
-        config.insert(
-            Value::String("topics".to_string()),
-            Value::Mapping(topic_config),
-        );
     }
 
     serde_yaml::to_string(&Value::Mapping(config)).map_err(Error::Yaml)
@@ -87,45 +77,46 @@ fn build_kafka_config(
     cluster: &ResolvedKafkaCluster,
     _tls_certs: &Option<ResolvedTlsCerts>,
     auth: &ResolvedAuth,
+    topics: Option<&crate::crd::common::TopicSelection>,
+    connection: Option<&crate::crd::common::KafkaConnectionSpec>,
 ) -> Result<Value> {
     let mut kafka = serde_yaml::Mapping::new();
 
     kafka.insert(
         Value::String("bootstrap_servers".to_string()),
-        Value::String(cluster.bootstrap_servers.clone()),
+        Value::Sequence(vec![Value::String(cluster.bootstrap_servers.clone())]),
     );
 
-    // TLS config
-    if cluster.tls_enabled {
-        let mut tls = serde_yaml::Mapping::new();
-        tls.insert(Value::String("enabled".to_string()), Value::Bool(true));
-        // CA cert path (mounted from Strimzi secret)
-        tls.insert(
-            Value::String("ca_cert_path".to_string()),
+    let mut security = serde_yaml::Mapping::new();
+    let security_protocol = match (cluster.tls_enabled, auth) {
+        (_, ResolvedAuth::Tls { .. }) => "SSL",
+        (true, ResolvedAuth::ScramSha512 { .. }) => "SASL_SSL",
+        (false, ResolvedAuth::ScramSha512 { .. }) => "SASL_PLAINTEXT",
+        (true, ResolvedAuth::None) => "SSL",
+        (false, ResolvedAuth::None) => "PLAINTEXT",
+    };
+    security.insert(
+        Value::String("security_protocol".to_string()),
+        Value::String(security_protocol.to_string()),
+    );
+
+    if cluster.tls_enabled || matches!(auth, ResolvedAuth::Tls { .. }) {
+        security.insert(
+            Value::String("ssl_ca_location".to_string()),
             Value::String("/certs/cluster-ca/ca.crt".to_string()),
         );
-        kafka.insert(Value::String("tls".to_string()), Value::Mapping(tls));
     }
 
     // Authentication
     match auth {
         ResolvedAuth::Tls { secret_name: _ } => {
-            let mut auth_config = serde_yaml::Mapping::new();
-            auth_config.insert(
-                Value::String("type".to_string()),
-                Value::String("tls".to_string()),
-            );
-            auth_config.insert(
-                Value::String("cert_path".to_string()),
+            security.insert(
+                Value::String("ssl_certificate_location".to_string()),
                 Value::String("/certs/user/user.crt".to_string()),
             );
-            auth_config.insert(
-                Value::String("key_path".to_string()),
+            security.insert(
+                Value::String("ssl_key_location".to_string()),
                 Value::String("/certs/user/user.key".to_string()),
-            );
-            kafka.insert(
-                Value::String("authentication".to_string()),
-                Value::Mapping(auth_config),
             );
         }
         ResolvedAuth::ScramSha512 {
@@ -133,25 +124,43 @@ fn build_kafka_config(
             secret_name: _,
             password_key: _,
         } => {
-            let mut auth_config = serde_yaml::Mapping::new();
-            auth_config.insert(
-                Value::String("type".to_string()),
-                Value::String("scram-sha-512".to_string()),
+            security.insert(
+                Value::String("sasl_mechanism".to_string()),
+                Value::String("SCRAM-SHA-512".to_string()),
             );
-            auth_config.insert(
-                Value::String("username".to_string()),
+            security.insert(
+                Value::String("sasl_username".to_string()),
                 Value::String(username.clone()),
             );
-            auth_config.insert(
-                Value::String("password_file".to_string()),
-                Value::String("/certs/user/password".to_string()),
-            );
-            kafka.insert(
-                Value::String("authentication".to_string()),
-                Value::Mapping(auth_config),
+            security.insert(
+                Value::String("sasl_password".to_string()),
+                Value::String("${KAFKA_SASL_PASSWORD}".to_string()),
             );
         }
         ResolvedAuth::None => {}
+    }
+
+    kafka.insert(
+        Value::String("security".to_string()),
+        Value::Mapping(security),
+    );
+
+    if let Some(topics) = topics {
+        let topic_config = build_topic_selection(topics);
+        if let Value::Mapping(ref m) = topic_config {
+            if !m.is_empty() {
+                kafka.insert(Value::String("topics".to_string()), topic_config);
+            }
+        }
+    }
+
+    if let Some(connection) = connection {
+        let connection_config = build_connection_config(connection);
+        if let Value::Mapping(ref m) = connection_config {
+            if !m.is_empty() {
+                kafka.insert(Value::String("connection".to_string()), connection_config);
+            }
+        }
     }
 
     Ok(Value::Mapping(kafka))
@@ -161,12 +170,21 @@ fn build_kafka_config(
 fn build_backup_options(opts: &crate::crd::kafka_backup::BackupOptionsSpec) -> Result<Value> {
     let mut config = serde_yaml::Mapping::new();
 
+    if opts.encryption.as_ref().is_some_and(|e| e.enabled) {
+        return Err(Error::InvalidConfig(
+            "backup.encryption is not supported by the current kafka-backup core config"
+                .to_string(),
+        ));
+    }
+
     if let Some(compression) = &opts.compression {
         config.insert(
             Value::String("compression".to_string()),
             Value::String(compression.clone()),
         );
     }
+
+    insert_i32(&mut config, "compression_level", opts.compression_level);
 
     if let Some(segment_size) = opts.segment_size {
         config.insert(
@@ -175,6 +193,12 @@ fn build_backup_options(opts: &crate::crd::kafka_backup::BackupOptionsSpec) -> R
         );
     }
 
+    insert_u64(
+        &mut config,
+        "segment_max_interval_ms",
+        opts.segment_max_interval_ms,
+    );
+
     if let Some(parallelism) = opts.parallelism {
         config.insert(
             Value::String("max_concurrent_partitions".to_string()),
@@ -182,7 +206,199 @@ fn build_backup_options(opts: &crate::crd::kafka_backup::BackupOptionsSpec) -> R
         );
     }
 
+    if let Some(start_offset) = &opts.start_offset {
+        config.insert(
+            Value::String("start_offset".to_string()),
+            Value::String(start_offset.clone()),
+        );
+    }
+
+    insert_bool(&mut config, "continuous", opts.continuous);
+    insert_bool(
+        &mut config,
+        "include_internal_topics",
+        opts.include_internal_topics,
+    );
+    if !opts.internal_topics.is_empty() {
+        config.insert(
+            Value::String("internal_topics".to_string()),
+            Value::Sequence(
+                opts.internal_topics
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    insert_u64(
+        &mut config,
+        "checkpoint_interval_secs",
+        opts.checkpoint_interval_secs,
+    );
+    insert_u64(&mut config, "sync_interval_secs", opts.sync_interval_secs);
+    insert_bool(
+        &mut config,
+        "include_offset_headers",
+        opts.include_offset_headers,
+    );
+    if let Some(source_cluster_id) = &opts.source_cluster_id {
+        config.insert(
+            Value::String("source_cluster_id".to_string()),
+            Value::String(source_cluster_id.clone()),
+        );
+    }
+    insert_bool(
+        &mut config,
+        "stop_at_current_offsets",
+        opts.stop_at_current_offsets,
+    );
+    insert_u64(&mut config, "poll_interval_ms", opts.poll_interval_ms);
+    insert_bool(
+        &mut config,
+        "consumer_group_snapshot",
+        opts.consumer_group_snapshot,
+    );
+
     Ok(Value::Mapping(config))
+}
+
+fn build_topic_selection(topics: &crate::crd::common::TopicSelection) -> Value {
+    let mut topic_config = serde_yaml::Mapping::new();
+    if !topics.include.is_empty() {
+        topic_config.insert(
+            Value::String("include".to_string()),
+            Value::Sequence(
+                topics
+                    .include
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    if !topics.exclude.is_empty() {
+        topic_config.insert(
+            Value::String("exclude".to_string()),
+            Value::Sequence(
+                topics
+                    .exclude
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    Value::Mapping(topic_config)
+}
+
+fn build_connection_config(connection: &crate::crd::common::KafkaConnectionSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+    insert_bool(&mut config, "tcp_keepalive", connection.tcp_keepalive);
+    insert_u64(
+        &mut config,
+        "keepalive_time_secs",
+        connection.keepalive_time_secs,
+    );
+    insert_u64(
+        &mut config,
+        "keepalive_interval_secs",
+        connection.keepalive_interval_secs,
+    );
+    insert_bool(&mut config, "tcp_nodelay", connection.tcp_nodelay);
+    if let Some(connections_per_broker) = connection.connections_per_broker {
+        config.insert(
+            Value::String("connections_per_broker".to_string()),
+            Value::Number(serde_yaml::Number::from(connections_per_broker as u64)),
+        );
+    }
+    Value::Mapping(config)
+}
+
+fn build_metrics_options(metrics: &crate::crd::common::MetricsSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+    insert_bool(&mut config, "enabled", metrics.enabled);
+    if let Some(port) = metrics.port {
+        config.insert(
+            Value::String("port".to_string()),
+            Value::Number(serde_yaml::Number::from(port)),
+        );
+    }
+    if let Some(bind_address) = &metrics.bind_address {
+        config.insert(
+            Value::String("bind_address".to_string()),
+            Value::String(bind_address.clone()),
+        );
+    }
+    if let Some(path) = &metrics.path {
+        config.insert(
+            Value::String("path".to_string()),
+            Value::String(path.clone()),
+        );
+    }
+    insert_u64(
+        &mut config,
+        "update_interval_ms",
+        metrics.update_interval_ms,
+    );
+    if let Some(max_partition_labels) = metrics.max_partition_labels {
+        config.insert(
+            Value::String("max_partition_labels".to_string()),
+            Value::Number(serde_yaml::Number::from(max_partition_labels as u64)),
+        );
+    }
+    Value::Mapping(config)
+}
+
+fn build_offset_storage_options(offset_storage: &crate::crd::common::OffsetStorageSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+    if let Some(backend) = &offset_storage.backend {
+        config.insert(
+            Value::String("backend".to_string()),
+            Value::String(backend.clone()),
+        );
+    }
+    if let Some(db_path) = &offset_storage.db_path {
+        config.insert(
+            Value::String("db_path".to_string()),
+            Value::String(db_path.clone()),
+        );
+    }
+    if let Some(s3_key) = &offset_storage.s3_key {
+        config.insert(
+            Value::String("s3_key".to_string()),
+            Value::String(s3_key.clone()),
+        );
+    }
+    insert_u64(
+        &mut config,
+        "sync_interval_secs",
+        offset_storage.sync_interval_secs,
+    );
+    Value::Mapping(config)
+}
+
+fn insert_bool(config: &mut serde_yaml::Mapping, key: &str, value: Option<bool>) {
+    if let Some(value) = value {
+        config.insert(Value::String(key.to_string()), Value::Bool(value));
+    }
+}
+
+fn insert_i32(config: &mut serde_yaml::Mapping, key: &str, value: Option<i32>) {
+    if let Some(value) = value {
+        config.insert(
+            Value::String(key.to_string()),
+            Value::Number(serde_yaml::Number::from(value)),
+        );
+    }
+}
+
+fn insert_u64(config: &mut serde_yaml::Mapping, key: &str, value: Option<u64>) {
+    if let Some(value) = value {
+        config.insert(
+            Value::String(key.to_string()),
+            Value::Number(serde_yaml::Number::from(value)),
+        );
+    }
 }
 
 #[cfg(test)]
@@ -202,6 +418,7 @@ mod tests {
                 include: vec!["orders.*".to_string()],
                 exclude: vec!["__.*".to_string()],
             }),
+            connection: None,
             storage: StorageSpec {
                 storage_type: StorageType::S3,
                 s3: Some(S3StorageSpec {
@@ -210,17 +427,36 @@ mod tests {
                     prefix: None,
                     endpoint: None,
                     force_path_style: None,
+                    allow_http: None,
                     credentials_secret: None,
+                    access_key_secret: None,
+                    secret_key_secret: None,
                 }),
                 azure: None,
                 gcs: None,
+                filesystem: None,
             },
             backup: Some(BackupOptionsSpec {
                 compression: Some("zstd".to_string()),
+                compression_level: None,
                 encryption: None,
                 segment_size: Some(268435456),
+                segment_max_interval_ms: None,
                 parallelism: Some(4),
+                start_offset: None,
+                continuous: None,
+                include_internal_topics: None,
+                internal_topics: Vec::new(),
+                checkpoint_interval_secs: None,
+                sync_interval_secs: None,
+                include_offset_headers: None,
+                source_cluster_id: None,
+                stop_at_current_offsets: None,
+                poll_interval_ms: None,
+                consumer_group_snapshot: None,
             }),
+            metrics: None,
+            offset_storage: None,
             schedule: None,
             retention: None,
             resources: None,

--- a/src/adapters/restore_config.rs
+++ b/src/adapters/restore_config.rs
@@ -24,16 +24,14 @@ pub fn build_restore_config_yaml(
         Value::String("restore".to_string()),
     );
 
-    // Backup ID (from backupRef or latest)
-    if let Some(backup_id) = &restore.spec.backup_ref.backup_id {
-        config.insert(
-            Value::String("backup_id".to_string()),
-            Value::String(backup_id.clone()),
-        );
-    }
+    let backup_id = resolve_backup_id(restore, source_backup)?;
+    config.insert(
+        Value::String("backup_id".to_string()),
+        Value::String(backup_id),
+    );
 
     // Target (Kafka cluster)
-    let target = build_kafka_config(cluster, tls_certs, auth)?;
+    let target = build_kafka_config(cluster, tls_certs, auth, restore.spec.connection.as_ref())?;
     config.insert(Value::String("target".to_string()), target);
 
     // Storage (from source backup CR)
@@ -48,27 +46,127 @@ pub fn build_restore_config_yaml(
         }
     }
 
-    // Point-in-time recovery
-    if let Some(pitr) = &restore.spec.point_in_time {
-        if let Some(timestamp) = &pitr.timestamp {
-            // Parse ISO 8601 to epoch ms
-            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(timestamp) {
-                config.insert(
-                    Value::String("time_window_end".to_string()),
-                    Value::Number(serde_yaml::Number::from(dt.timestamp_millis())),
-                );
-            } else {
-                return Err(Error::InvalidConfig(format!(
-                    "Invalid timestamp format: {timestamp}"
-                )));
+    // Metrics options
+    if let Some(metrics) = &restore.spec.metrics {
+        let opts = build_metrics_options(metrics);
+        if let Value::Mapping(ref m) = opts {
+            if !m.is_empty() {
+                config.insert(Value::String("metrics".to_string()), opts);
             }
         }
-        if let Some(offset) = &pitr.offset_from_end {
-            // Store as duration string — the CLI will handle parsing
-            config.insert(
-                Value::String("offset_from_end".to_string()),
-                Value::String(offset.clone()),
+    }
+
+    serde_yaml::to_string(&Value::Mapping(config)).map_err(Error::Yaml)
+}
+
+/// Build the Kafka connection config for the restore target
+fn build_kafka_config(
+    cluster: &ResolvedKafkaCluster,
+    _tls_certs: &Option<ResolvedTlsCerts>,
+    auth: &ResolvedAuth,
+    connection: Option<&crate::crd::common::KafkaConnectionSpec>,
+) -> Result<Value> {
+    let mut kafka = serde_yaml::Mapping::new();
+
+    kafka.insert(
+        Value::String("bootstrap_servers".to_string()),
+        Value::Sequence(vec![Value::String(cluster.bootstrap_servers.clone())]),
+    );
+
+    let mut security = serde_yaml::Mapping::new();
+    let security_protocol = match (cluster.tls_enabled, auth) {
+        (_, ResolvedAuth::Tls { .. }) => "SSL",
+        (true, ResolvedAuth::ScramSha512 { .. }) => "SASL_SSL",
+        (false, ResolvedAuth::ScramSha512 { .. }) => "SASL_PLAINTEXT",
+        (true, ResolvedAuth::None) => "SSL",
+        (false, ResolvedAuth::None) => "PLAINTEXT",
+    };
+    security.insert(
+        Value::String("security_protocol".to_string()),
+        Value::String(security_protocol.to_string()),
+    );
+
+    if cluster.tls_enabled || matches!(auth, ResolvedAuth::Tls { .. }) {
+        security.insert(
+            Value::String("ssl_ca_location".to_string()),
+            Value::String("/certs/cluster-ca/ca.crt".to_string()),
+        );
+    }
+
+    match auth {
+        ResolvedAuth::Tls { .. } => {
+            security.insert(
+                Value::String("ssl_certificate_location".to_string()),
+                Value::String("/certs/user/user.crt".to_string()),
             );
+            security.insert(
+                Value::String("ssl_key_location".to_string()),
+                Value::String("/certs/user/user.key".to_string()),
+            );
+        }
+        ResolvedAuth::ScramSha512 { username, .. } => {
+            security.insert(
+                Value::String("sasl_mechanism".to_string()),
+                Value::String("SCRAM-SHA-512".to_string()),
+            );
+            security.insert(
+                Value::String("sasl_username".to_string()),
+                Value::String(username.clone()),
+            );
+            security.insert(
+                Value::String("sasl_password".to_string()),
+                Value::String("${KAFKA_SASL_PASSWORD}".to_string()),
+            );
+        }
+        ResolvedAuth::None => {}
+    }
+
+    kafka.insert(
+        Value::String("security".to_string()),
+        Value::Mapping(security),
+    );
+
+    if let Some(connection) = connection {
+        let connection_config = build_connection_config(connection);
+        if let Value::Mapping(ref m) = connection_config {
+            if !m.is_empty() {
+                kafka.insert(Value::String("connection".to_string()), connection_config);
+            }
+        }
+    }
+
+    Ok(Value::Mapping(kafka))
+}
+
+/// Build restore-specific options
+fn build_restore_options(restore: &KafkaRestore) -> Result<Value> {
+    let mut config = serde_yaml::Mapping::new();
+
+    // Point-in-time recovery
+    if let Some(pitr) = &restore.spec.point_in_time {
+        if let Some(timestamp) = &pitr.start_timestamp {
+            let dt = chrono::DateTime::parse_from_rfc3339(timestamp).map_err(|_| {
+                Error::InvalidConfig(format!("Invalid startTimestamp format: {timestamp}"))
+            })?;
+            config.insert(
+                Value::String("time_window_start".to_string()),
+                Value::Number(serde_yaml::Number::from(dt.timestamp_millis())),
+            );
+        }
+        if let Some(timestamp) = &pitr.timestamp {
+            let dt = chrono::DateTime::parse_from_rfc3339(timestamp).map_err(|_| {
+                Error::InvalidConfig(format!("Invalid timestamp format: {timestamp}"))
+            })?;
+            config.insert(
+                Value::String("time_window_end".to_string()),
+                Value::Number(serde_yaml::Number::from(dt.timestamp_millis())),
+            );
+        }
+        if pitr.offset_from_end.is_some() {
+            return Err(Error::InvalidConfig(
+                "pointInTime.offsetFromEnd is not supported by the current kafka-backup core config"
+                    .to_string(),
+            ));
         }
     }
 
@@ -87,86 +185,131 @@ pub fn build_restore_config_yaml(
         );
     }
 
-    serde_yaml::to_string(&Value::Mapping(config)).map_err(Error::Yaml)
-}
-
-/// Build the Kafka connection config for the restore target
-fn build_kafka_config(
-    cluster: &ResolvedKafkaCluster,
-    _tls_certs: &Option<ResolvedTlsCerts>,
-    auth: &ResolvedAuth,
-) -> Result<Value> {
-    let mut kafka = serde_yaml::Mapping::new();
-
-    kafka.insert(
-        Value::String("bootstrap_servers".to_string()),
-        Value::String(cluster.bootstrap_servers.clone()),
-    );
-
-    if cluster.tls_enabled {
-        let mut tls = serde_yaml::Mapping::new();
-        tls.insert(Value::String("enabled".to_string()), Value::Bool(true));
-        tls.insert(
-            Value::String("ca_cert_path".to_string()),
-            Value::String("/certs/cluster-ca/ca.crt".to_string()),
-        );
-        kafka.insert(Value::String("tls".to_string()), Value::Mapping(tls));
-    }
-
-    match auth {
-        ResolvedAuth::Tls { .. } => {
-            let mut auth_config = serde_yaml::Mapping::new();
-            auth_config.insert(
-                Value::String("type".to_string()),
-                Value::String("tls".to_string()),
-            );
-            auth_config.insert(
-                Value::String("cert_path".to_string()),
-                Value::String("/certs/user/user.crt".to_string()),
-            );
-            auth_config.insert(
-                Value::String("key_path".to_string()),
-                Value::String("/certs/user/user.key".to_string()),
-            );
-            kafka.insert(
-                Value::String("authentication".to_string()),
-                Value::Mapping(auth_config),
-            );
-        }
-        ResolvedAuth::ScramSha512 { username, .. } => {
-            let mut auth_config = serde_yaml::Mapping::new();
-            auth_config.insert(
-                Value::String("type".to_string()),
-                Value::String("scram-sha-512".to_string()),
-            );
-            auth_config.insert(
-                Value::String("username".to_string()),
-                Value::String(username.clone()),
-            );
-            auth_config.insert(
-                Value::String("password_file".to_string()),
-                Value::String("/certs/user/password".to_string()),
-            );
-            kafka.insert(
-                Value::String("authentication".to_string()),
-                Value::Mapping(auth_config),
-            );
-        }
-        ResolvedAuth::None => {}
-    }
-
-    Ok(Value::Mapping(kafka))
-}
-
-/// Build restore-specific options
-fn build_restore_options(restore: &KafkaRestore) -> Result<Value> {
-    let mut config = serde_yaml::Mapping::new();
-
     if let Some(opts) = &restore.spec.restore {
+        insert_bool(&mut config, "dry_run", opts.dry_run);
+        insert_bool(
+            &mut config,
+            "include_original_offset_header",
+            opts.include_original_offset_header,
+        );
+        if !opts.source_partitions.is_empty() {
+            config.insert(
+                Value::String("source_partitions".to_string()),
+                Value::Sequence(
+                    opts.source_partitions
+                        .iter()
+                        .map(|p| Value::Number(serde_yaml::Number::from(*p)))
+                        .collect(),
+                ),
+            );
+        }
+        if !opts.partition_mapping.is_empty() {
+            let mut mapping = serde_yaml::Mapping::new();
+            for entry in &opts.partition_mapping {
+                mapping.insert(
+                    Value::Number(serde_yaml::Number::from(entry.source_partition)),
+                    Value::Number(serde_yaml::Number::from(entry.target_partition)),
+                );
+            }
+            config.insert(
+                Value::String("partition_mapping".to_string()),
+                Value::Mapping(mapping),
+            );
+        }
         if let Some(parallelism) = opts.parallelism {
             config.insert(
                 Value::String("max_concurrent_partitions".to_string()),
                 Value::Number(serde_yaml::Number::from(parallelism as i64)),
+            );
+        }
+        insert_u64(
+            &mut config,
+            "rate_limit_records_per_sec",
+            opts.rate_limit_records_per_sec,
+        );
+        insert_u64(
+            &mut config,
+            "rate_limit_bytes_per_sec",
+            opts.rate_limit_bytes_per_sec,
+        );
+        if let Some(produce_batch_size) = opts.produce_batch_size {
+            config.insert(
+                Value::String("produce_batch_size".to_string()),
+                Value::Number(serde_yaml::Number::from(produce_batch_size as u64)),
+            );
+        }
+        if let Some(produce_acks) = opts.produce_acks {
+            config.insert(
+                Value::String("produce_acks".to_string()),
+                Value::Number(serde_yaml::Number::from(produce_acks)),
+            );
+        }
+        if let Some(produce_timeout_ms) = opts.produce_timeout_ms {
+            config.insert(
+                Value::String("produce_timeout_ms".to_string()),
+                Value::Number(serde_yaml::Number::from(produce_timeout_ms)),
+            );
+        }
+        if let Some(checkpoint_state) = &opts.checkpoint_state {
+            config.insert(
+                Value::String("checkpoint_state".to_string()),
+                Value::String(checkpoint_state.clone()),
+            );
+        }
+        insert_u64(
+            &mut config,
+            "checkpoint_interval_secs",
+            opts.checkpoint_interval_secs,
+        );
+        if let Some(topic_creation) = &opts.topic_creation {
+            insert_bool(
+                &mut config,
+                "create_topics",
+                Some(*topic_creation == crate::crd::kafka_restore::TopicCreationPolicy::Auto),
+            );
+        }
+        if let Some(default_replication_factor) = opts.default_replication_factor {
+            config.insert(
+                Value::String("default_replication_factor".to_string()),
+                Value::Number(serde_yaml::Number::from(default_replication_factor)),
+            );
+        }
+        if let Some(existing_topic_policy) = &opts.existing_topic_policy {
+            match existing_topic_policy {
+                crate::crd::kafka_restore::ExistingTopicPolicy::Overwrite => {
+                    config.insert(Value::String("purge_topics".to_string()), Value::Bool(true));
+                }
+                crate::crd::kafka_restore::ExistingTopicPolicy::Append => {}
+                crate::crd::kafka_restore::ExistingTopicPolicy::Fail => {
+                    return Err(Error::InvalidConfig(
+                        "restore.existingTopicPolicy: fail is not supported by the current kafka-backup core config".to_string(),
+                    ));
+                }
+            }
+        }
+        insert_bool(&mut config, "purge_topics", opts.purge_topics);
+        if !opts.repartitioning.is_empty() {
+            let mut repartitioning = serde_yaml::Mapping::new();
+            for entry in &opts.repartitioning {
+                let mut topic_config = serde_yaml::Mapping::new();
+                if let Some(strategy) = &entry.strategy {
+                    topic_config.insert(
+                        Value::String("strategy".to_string()),
+                        Value::String(strategy.clone()),
+                    );
+                }
+                topic_config.insert(
+                    Value::String("target_partitions".to_string()),
+                    Value::Number(serde_yaml::Number::from(entry.target_partitions)),
+                );
+                repartitioning.insert(
+                    Value::String(entry.topic.clone()),
+                    Value::Mapping(topic_config),
+                );
+            }
+            config.insert(
+                Value::String("repartitioning".to_string()),
+                Value::Mapping(repartitioning),
             );
         }
     }
@@ -174,25 +317,152 @@ fn build_restore_options(restore: &KafkaRestore) -> Result<Value> {
     // Consumer group restore
     if let Some(cg) = &restore.spec.consumer_groups {
         if cg.restore {
-            config.insert(
-                Value::String("restore_consumer_groups".to_string()),
-                Value::Bool(true),
-            );
+            let has_explicit_groups = !cg.mapping.is_empty() || !cg.groups.is_empty();
+            let auto_groups = cg.auto.unwrap_or(false);
+            if has_explicit_groups {
+                config.insert(
+                    Value::String("reset_consumer_offsets".to_string()),
+                    Value::Bool(true),
+                );
+            } else if !auto_groups {
+                return Err(Error::InvalidConfig(
+                    "consumerGroups.restore requires consumerGroups.groups, consumerGroups.mapping, or consumerGroups.auto: true".to_string(),
+                ));
+            }
+            if let Some(strategy) = &cg.strategy {
+                config.insert(
+                    Value::String("consumer_group_strategy".to_string()),
+                    Value::String(strategy.clone()),
+                );
+            }
+            if let Some(offset_report) = &cg.offset_report {
+                config.insert(
+                    Value::String("offset_report".to_string()),
+                    Value::String(offset_report.clone()),
+                );
+            }
+            insert_bool(&mut config, "auto_consumer_groups", cg.auto);
             if !cg.mapping.is_empty() {
-                let mut group_mapping = serde_yaml::Mapping::new();
                 for entry in &cg.mapping {
-                    group_mapping.insert(
-                        Value::String(entry.source_group.clone()),
-                        Value::String(entry.target_group.clone()),
-                    );
+                    if entry.source_group != entry.target_group {
+                        return Err(Error::InvalidConfig(
+                            "consumerGroups.mapping with different sourceGroup and targetGroup is not supported by the current kafka-backup core config".to_string(),
+                        ));
+                    }
                 }
                 config.insert(
-                    Value::String("consumer_group_mapping".to_string()),
-                    Value::Mapping(group_mapping),
+                    Value::String("consumer_groups".to_string()),
+                    Value::Sequence(
+                        cg.mapping
+                            .iter()
+                            .map(|entry| Value::String(entry.target_group.clone()))
+                            .collect(),
+                    ),
+                );
+            } else if !cg.groups.is_empty() {
+                config.insert(
+                    Value::String("consumer_groups".to_string()),
+                    Value::Sequence(
+                        cg.groups
+                            .iter()
+                            .map(|group| Value::String(group.clone()))
+                            .collect(),
+                    ),
                 );
             }
         }
     }
 
     Ok(Value::Mapping(config))
+}
+
+fn resolve_backup_id(restore: &KafkaRestore, source_backup: &KafkaBackup) -> Result<String> {
+    if let Some(backup_id) = &restore.spec.backup_ref.backup_id {
+        return Ok(backup_id.clone());
+    }
+
+    source_backup
+        .status
+        .as_ref()
+        .and_then(|status| status.last_backup.as_ref())
+        .map(|last_backup| last_backup.id.clone())
+        .ok_or_else(|| {
+            Error::InvalidConfig(
+                "backupRef.backupId is required when the source KafkaBackup has no status.lastBackup.id"
+                    .to_string(),
+            )
+        })
+}
+
+fn build_connection_config(connection: &crate::crd::common::KafkaConnectionSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+    insert_bool(&mut config, "tcp_keepalive", connection.tcp_keepalive);
+    insert_u64(
+        &mut config,
+        "keepalive_time_secs",
+        connection.keepalive_time_secs,
+    );
+    insert_u64(
+        &mut config,
+        "keepalive_interval_secs",
+        connection.keepalive_interval_secs,
+    );
+    insert_bool(&mut config, "tcp_nodelay", connection.tcp_nodelay);
+    if let Some(connections_per_broker) = connection.connections_per_broker {
+        config.insert(
+            Value::String("connections_per_broker".to_string()),
+            Value::Number(serde_yaml::Number::from(connections_per_broker as u64)),
+        );
+    }
+    Value::Mapping(config)
+}
+
+fn build_metrics_options(metrics: &crate::crd::common::MetricsSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+    insert_bool(&mut config, "enabled", metrics.enabled);
+    if let Some(port) = metrics.port {
+        config.insert(
+            Value::String("port".to_string()),
+            Value::Number(serde_yaml::Number::from(port)),
+        );
+    }
+    if let Some(bind_address) = &metrics.bind_address {
+        config.insert(
+            Value::String("bind_address".to_string()),
+            Value::String(bind_address.clone()),
+        );
+    }
+    if let Some(path) = &metrics.path {
+        config.insert(
+            Value::String("path".to_string()),
+            Value::String(path.clone()),
+        );
+    }
+    insert_u64(
+        &mut config,
+        "update_interval_ms",
+        metrics.update_interval_ms,
+    );
+    if let Some(max_partition_labels) = metrics.max_partition_labels {
+        config.insert(
+            Value::String("max_partition_labels".to_string()),
+            Value::Number(serde_yaml::Number::from(max_partition_labels as u64)),
+        );
+    }
+    Value::Mapping(config)
+}
+
+fn insert_bool(config: &mut serde_yaml::Mapping, key: &str, value: Option<bool>) {
+    if let Some(value) = value {
+        config.insert(Value::String(key.to_string()), Value::Bool(value));
+    }
+}
+
+fn insert_u64(config: &mut serde_yaml::Mapping, key: &str, value: Option<u64>) {
+    if let Some(value) = value {
+        config.insert(
+            Value::String(key.to_string()),
+            Value::Number(serde_yaml::Number::from(value)),
+        );
+    }
 }

--- a/src/adapters/storage_config.rs
+++ b/src/adapters/storage_config.rs
@@ -9,6 +9,7 @@ pub fn build_storage_config(storage: &StorageSpec) -> Result<Value> {
         StorageType::S3 => build_s3_config(storage),
         StorageType::Azure => build_azure_config(storage),
         StorageType::Gcs => build_gcs_config(storage),
+        StorageType::Filesystem => build_filesystem_config(storage),
     }
 }
 
@@ -19,7 +20,7 @@ fn build_s3_config(storage: &StorageSpec) -> Result<Value> {
 
     let mut config = serde_yaml::Mapping::new();
     config.insert(
-        Value::String("type".to_string()),
+        Value::String("backend".to_string()),
         Value::String("s3".to_string()),
     );
     config.insert(
@@ -50,17 +51,29 @@ fn build_s3_config(storage: &StorageSpec) -> Result<Value> {
 
     if let Some(force_path_style) = s3.force_path_style {
         config.insert(
-            Value::String("force_path_style".to_string()),
+            Value::String("path_style".to_string()),
             Value::Bool(force_path_style),
         );
     }
 
-    // Credentials are mounted as environment variables or files by the Job
-    // The path is set to /credentials/ in the Job spec
-    if s3.credentials_secret.is_some() {
+    if let Some(allow_http) = s3.allow_http {
         config.insert(
-            Value::String("credentials_file".to_string()),
-            Value::String("/credentials/credentials".to_string()),
+            Value::String("allow_http".to_string()),
+            Value::Bool(allow_http),
+        );
+    }
+
+    if s3.access_key_secret.is_some() {
+        config.insert(
+            Value::String("access_key".to_string()),
+            Value::String("${AWS_ACCESS_KEY_ID}".to_string()),
+        );
+    }
+
+    if s3.secret_key_secret.is_some() {
+        config.insert(
+            Value::String("secret_key".to_string()),
+            Value::String("${AWS_SECRET_ACCESS_KEY}".to_string()),
         );
     }
 
@@ -74,15 +87,15 @@ fn build_azure_config(storage: &StorageSpec) -> Result<Value> {
 
     let mut config = serde_yaml::Mapping::new();
     config.insert(
-        Value::String("type".to_string()),
+        Value::String("backend".to_string()),
         Value::String("azure".to_string()),
     );
     config.insert(
-        Value::String("container".to_string()),
+        Value::String("container_name".to_string()),
         Value::String(azure.container.clone()),
     );
     config.insert(
-        Value::String("storage_account".to_string()),
+        Value::String("account_name".to_string()),
         Value::String(azure.storage_account.clone()),
     );
 
@@ -93,10 +106,52 @@ fn build_azure_config(storage: &StorageSpec) -> Result<Value> {
         );
     }
 
-    if azure.credentials_secret.is_some() {
+    if azure.credentials_secret.is_some() || azure.account_key_secret.is_some() {
         config.insert(
-            Value::String("credentials_file".to_string()),
-            Value::String("/credentials/credentials".to_string()),
+            Value::String("account_key".to_string()),
+            Value::String("${AZURE_STORAGE_KEY}".to_string()),
+        );
+    }
+
+    if azure.sas_token_secret.is_some() {
+        config.insert(
+            Value::String("sas_token".to_string()),
+            Value::String("${AZURE_STORAGE_SAS_TOKEN}".to_string()),
+        );
+    }
+
+    if azure.client_secret_secret.is_some() {
+        config.insert(
+            Value::String("client_secret".to_string()),
+            Value::String("${AZURE_CLIENT_SECRET}".to_string()),
+        );
+    }
+
+    if let Some(endpoint) = &azure.endpoint {
+        config.insert(
+            Value::String("endpoint".to_string()),
+            Value::String(endpoint.clone()),
+        );
+    }
+
+    if let Some(use_workload_identity) = azure.use_workload_identity {
+        config.insert(
+            Value::String("use_workload_identity".to_string()),
+            Value::Bool(use_workload_identity),
+        );
+    }
+
+    if let Some(client_id) = &azure.client_id {
+        config.insert(
+            Value::String("client_id".to_string()),
+            Value::String(client_id.clone()),
+        );
+    }
+
+    if let Some(tenant_id) = &azure.tenant_id {
+        config.insert(
+            Value::String("tenant_id".to_string()),
+            Value::String(tenant_id.clone()),
         );
     }
 
@@ -110,7 +165,7 @@ fn build_gcs_config(storage: &StorageSpec) -> Result<Value> {
 
     let mut config = serde_yaml::Mapping::new();
     config.insert(
-        Value::String("type".to_string()),
+        Value::String("backend".to_string()),
         Value::String("gcs".to_string()),
     );
     config.insert(
@@ -127,10 +182,35 @@ fn build_gcs_config(storage: &StorageSpec) -> Result<Value> {
 
     if gcs.credentials_secret.is_some() {
         config.insert(
-            Value::String("credentials_file".to_string()),
+            Value::String("service_account_path".to_string()),
             Value::String("/credentials/credentials".to_string()),
         );
+    } else if let Some(service_account_path) = &gcs.service_account_path {
+        config.insert(
+            Value::String("service_account_path".to_string()),
+            Value::String(service_account_path.clone()),
+        );
     }
+
+    Ok(Value::Mapping(config))
+}
+
+fn build_filesystem_config(storage: &StorageSpec) -> Result<Value> {
+    let filesystem = storage.filesystem.as_ref().ok_or_else(|| {
+        Error::InvalidConfig(
+            "Storage type is Filesystem but filesystem config is missing".to_string(),
+        )
+    })?;
+
+    let mut config = serde_yaml::Mapping::new();
+    config.insert(
+        Value::String("backend".to_string()),
+        Value::String("filesystem".to_string()),
+    );
+    config.insert(
+        Value::String("path".to_string()),
+        Value::String(filesystem.path.clone()),
+    );
 
     Ok(Value::Mapping(config))
 }
@@ -153,6 +233,7 @@ pub fn get_storage_credentials_secret(storage: &StorageSpec) -> Option<(String, 
             .as_ref()
             .and_then(|g| g.credentials_secret.as_ref())
             .map(|s| (s.name.clone(), s.key.clone())),
+        StorageType::Filesystem => None,
     }
 }
 
@@ -171,19 +252,23 @@ mod tests {
                 prefix: Some("backups/".to_string()),
                 endpoint: None,
                 force_path_style: None,
+                allow_http: None,
                 credentials_secret: Some(SecretKeyRef {
                     name: "aws-creds".to_string(),
                     key: "credentials".to_string(),
                 }),
+                access_key_secret: None,
+                secret_key_secret: None,
             }),
             azure: None,
             gcs: None,
+            filesystem: None,
         };
 
         let config = build_storage_config(&storage).unwrap();
         let mapping = config.as_mapping().unwrap();
         assert_eq!(
-            mapping.get(Value::String("type".to_string())),
+            mapping.get(Value::String("backend".to_string())),
             Some(&Value::String("s3".to_string()))
         );
         assert_eq!(

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -115,14 +115,14 @@ pub struct SecretKeyRef {
     pub key: String,
 }
 
-/// Topic selection with include/exclude regex patterns
+/// Topic selection with include/exclude glob patterns
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TopicSelection {
-    /// Regex patterns for topics to include
+    /// Glob patterns for topics to include
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<String>,
-    /// Regex patterns for topics to exclude
+    /// Glob patterns for topics to exclude
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
 }
@@ -137,6 +137,69 @@ pub struct ConsumerGroupSelection {
     /// Regex patterns for consumer groups to exclude
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
+}
+
+/// Kafka TCP connection tuning passed through to kafka-backup.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct KafkaConnectionSpec {
+    /// Enable TCP keepalive
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_keepalive: Option<bool>,
+    /// Seconds before the first keepalive probe
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keepalive_time_secs: Option<u64>,
+    /// Seconds between keepalive probes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keepalive_interval_secs: Option<u64>,
+    /// Enable TCP_NODELAY
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_nodelay: Option<bool>,
+    /// TCP connections to keep per broker
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connections_per_broker: Option<usize>,
+}
+
+/// Metrics HTTP server configuration for kafka-backup job pods.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsSpec {
+    /// Enable the kafka-backup metrics server
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Metrics HTTP port
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    /// Metrics bind address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bind_address: Option<String>,
+    /// Metrics endpoint path
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Metrics recalculation interval in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_interval_ms: Option<u64>,
+    /// Maximum topic/partition labels emitted by the core metrics registry
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_partition_labels: Option<usize>,
+}
+
+/// Offset storage configuration for continuous backup progress.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OffsetStorageSpec {
+    /// Offset storage backend: sqlite or memory
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    /// Path to the local SQLite database file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub db_path: Option<String>,
+    /// Remote S3 key used to sync the offset database
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub s3_key: Option<String>,
+    /// Remote sync interval in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_interval_secs: Option<u64>,
 }
 
 // --- Storage types ---
@@ -157,6 +220,9 @@ pub struct StorageSpec {
     /// Google Cloud Storage configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gcs: Option<GcsStorageSpec>,
+    /// Filesystem storage configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystem: Option<FilesystemStorageSpec>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -165,6 +231,7 @@ pub enum StorageType {
     S3,
     Azure,
     Gcs,
+    Filesystem,
 }
 
 /// S3-compatible storage configuration
@@ -185,9 +252,18 @@ pub struct S3StorageSpec {
     /// Force path-style access (required for MinIO)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_path_style: Option<bool>,
+    /// Allow insecure HTTP connections
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_http: Option<bool>,
     /// Secret containing AWS credentials
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials_secret: Option<SecretKeyRef>,
+    /// Secret key containing AWS access key ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_key_secret: Option<SecretKeyRef>,
+    /// Secret key containing AWS secret access key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_key_secret: Option<SecretKeyRef>,
 }
 
 /// Azure Blob Storage configuration
@@ -204,6 +280,27 @@ pub struct AzureStorageSpec {
     /// Secret containing Azure credentials
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials_secret: Option<SecretKeyRef>,
+    /// Storage account key secret
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_key_secret: Option<SecretKeyRef>,
+    /// SAS token secret
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sas_token_secret: Option<SecretKeyRef>,
+    /// Service principal client secret
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret_secret: Option<SecretKeyRef>,
+    /// Custom endpoint for sovereign clouds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Enable Azure Workload Identity
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_workload_identity: Option<bool>,
+    /// Azure AD client ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// Azure AD tenant ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
 }
 
 /// Google Cloud Storage configuration
@@ -218,6 +315,17 @@ pub struct GcsStorageSpec {
     /// Secret containing GCS service account JSON
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials_secret: Option<SecretKeyRef>,
+    /// Path to a mounted service account JSON file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_account_path: Option<String>,
+}
+
+/// Local filesystem storage configuration.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FilesystemStorageSpec {
+    /// Base path for backup data
+    pub path: String,
 }
 
 // --- Pod template types ---

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -3,9 +3,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::common::{
-    AuthenticationSpec, BackupHistoryEntry, Condition, ConsumerGroupSelection, LastBackupInfo,
-    PodTemplateSpec, ResourceRequirementsSpec, SecretKeyRef, StorageSpec, StrimziClusterRef,
-    TopicSelection,
+    AuthenticationSpec, BackupHistoryEntry, Condition, ConsumerGroupSelection, KafkaConnectionSpec,
+    LastBackupInfo, MetricsSpec, OffsetStorageSpec, PodTemplateSpec, ResourceRequirementsSpec,
+    SecretKeyRef, StorageSpec, StrimziClusterRef, TopicSelection,
 };
 
 /// KafkaBackup defines a backup configuration for a Strimzi-managed Kafka cluster.
@@ -34,9 +34,13 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<AuthenticationSpec>,
 
-    /// Topic selection with include/exclude regex patterns
+    /// Topic selection with include/exclude glob patterns
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topics: Option<TopicSelection>,
+
+    /// Kafka connection tuning for the source cluster
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<KafkaConnectionSpec>,
 
     /// Consumer group selection
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,6 +52,14 @@ pub struct KafkaBackupSpec {
     /// Backup options (compression, encryption, parallelism)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup: Option<BackupOptionsSpec>,
+
+    /// Metrics configuration for backup job pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<MetricsSpec>,
+
+    /// Offset storage configuration for continuous backup progress
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset_storage: Option<OffsetStorageSpec>,
 
     /// Cron schedule configuration
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,9 +86,13 @@ pub struct KafkaBackupSpec {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BackupOptionsSpec {
-    /// Compression algorithm: none, gzip, snappy, lz4, zstd
+    /// Compression algorithm: none, lz4, zstd
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compression: Option<String>,
+
+    /// Compression level (zstd: 1-22)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compression_level: Option<i32>,
 
     /// Encryption configuration
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -86,9 +102,57 @@ pub struct BackupOptionsSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_size: Option<i64>,
 
+    /// Maximum segment time interval in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_max_interval_ms: Option<u64>,
+
     /// Number of concurrent partition backup threads (default: 4)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<i32>,
+
+    /// Starting offset for backups: earliest or latest
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_offset: Option<String>,
+
+    /// Run continuously instead of one-shot
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuous: Option<bool>,
+
+    /// Include internal Kafka topics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_internal_topics: Option<bool>,
+
+    /// Internal topics to include
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub internal_topics: Vec<String>,
+
+    /// Checkpoint interval in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_interval_secs: Option<u64>,
+
+    /// Remote offset database sync interval in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_interval_secs: Option<u64>,
+
+    /// Include original Kafka offset headers in backup records
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_offset_headers: Option<bool>,
+
+    /// Source cluster identifier written to record headers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_cluster_id: Option<String>,
+
+    /// Snapshot current high watermarks and exit when caught up
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_at_current_offsets: Option<bool>,
+
+    /// Continuous-mode poll interval in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_interval_ms: Option<u64>,
+
+    /// Snapshot consumer group offsets after each backup cycle
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consumer_group_snapshot: Option<bool>,
 }
 
 /// Encryption configuration for backups

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::common::{
-    AuthenticationSpec, Condition, PodTemplateSpec, ResourceRequirementsSpec, RestoreInfo,
-    StrimziClusterRef,
+    AuthenticationSpec, Condition, KafkaConnectionSpec, MetricsSpec, PodTemplateSpec,
+    ResourceRequirementsSpec, RestoreInfo, StrimziClusterRef,
 };
 
 /// KafkaRestore defines a restore operation from a KafkaBackup to a Strimzi-managed Kafka cluster.
@@ -39,6 +39,10 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub point_in_time: Option<PointInTimeSpec>,
 
+    /// Kafka connection tuning for the target cluster
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<KafkaConnectionSpec>,
+
     /// Topic mapping for renaming topics during restore
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub topic_mapping: Vec<TopicMappingEntry>,
@@ -50,6 +54,10 @@ pub struct KafkaRestoreSpec {
     /// Restore behaviour options
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restore: Option<RestoreOptionsSpec>,
+
+    /// Metrics configuration for restore job pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<MetricsSpec>,
 
     /// Resource requirements for restore pods
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,10 +87,13 @@ pub struct BackupRef {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PointInTimeSpec {
+    /// Start timestamp for the restore window (ISO 8601 with millisecond precision)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_timestamp: Option<String>,
     /// Exact timestamp to restore to (ISO 8601 with millisecond precision)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
-    /// Duration offset from backup end (e.g., "2h", "30m")
+    /// Duration offset from backup end (not supported by the current kafka-backup core)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset_from_end: Option<String>,
 }
@@ -104,6 +115,18 @@ pub struct ConsumerGroupRestoreSpec {
     /// Whether to restore consumer group offsets
     #[serde(default)]
     pub restore: bool,
+    /// Automatically load the consumer group snapshot from backup storage
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto: Option<bool>,
+    /// Consumer groups to reset
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<String>,
+    /// Offset handling strategy: skip, header-based, timestamp-based, cluster-scan, manual
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    /// Output file path for offset mapping report
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset_report: Option<String>,
     /// Consumer group mappings (source → target)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mapping: Vec<ConsumerGroupMapping>,
@@ -126,12 +149,77 @@ pub struct RestoreOptionsSpec {
     /// Topic creation strategy: auto or manual
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic_creation: Option<TopicCreationPolicy>,
-    /// Policy for existing topics: fail, append, or overwrite
+    /// Policy for existing topics: append or overwrite. fail is accepted for legacy CRs but rejected at runtime.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_topic_policy: Option<ExistingTopicPolicy>,
+    /// Dry-run mode: validate without writing records
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dry_run: Option<bool>,
+    /// Include original offsets as headers on restored records
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_original_offset_header: Option<bool>,
+    /// Source partitions to restore
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_partitions: Vec<i32>,
+    /// Partition mapping entries
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub partition_mapping: Vec<PartitionMappingEntry>,
     /// Number of concurrent restore threads (default: 4)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<i32>,
+    /// Rate limit in records per second
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_records_per_sec: Option<u64>,
+    /// Rate limit in bytes per second
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_bytes_per_sec: Option<u64>,
+    /// Produce batch size
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub produce_batch_size: Option<usize>,
+    /// Producer acks setting (-1, 0, or 1)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub produce_acks: Option<i16>,
+    /// Broker-side produce timeout in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub produce_timeout_ms: Option<i32>,
+    /// Checkpoint state file path
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_state: Option<String>,
+    /// Checkpoint interval in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_interval_secs: Option<u64>,
+    /// Replication factor for auto-created topics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_replication_factor: Option<i16>,
+    /// Per-topic repartitioning configuration
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repartitioning: Vec<TopicRepartitioningSpec>,
+    /// Purge target topics before restoring
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purge_topics: Option<bool>,
+}
+
+/// Mapping for source partition to target partition.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionMappingEntry {
+    /// Source partition number
+    pub source_partition: i32,
+    /// Target partition number
+    pub target_partition: i32,
+}
+
+/// Per-topic repartitioning configuration keyed by target topic name.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TopicRepartitioningSpec {
+    /// Target topic name
+    pub topic: String,
+    /// Partitioning strategy: murmur2 or automatic
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    /// Target partition count
+    pub target_partitions: i32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/src/jobs/backup_job.rs
+++ b/src/jobs/backup_job.rs
@@ -11,7 +11,7 @@ use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
     apply_pod_template, build_annotations, build_labels, build_volumes_and_mounts,
-    merge_template_labels,
+    job_name_env_var, merge_template_labels,
 };
 
 /// Build a Kubernetes Job spec for a backup operation
@@ -34,13 +34,15 @@ pub fn build_backup_job(
     let annotations = build_annotations(backup.spec.template.as_ref());
 
     // Build volumes and mounts
-    let (volumes, volume_mounts) = build_volumes_and_mounts(
+    let (volumes, volume_mounts, mut env) = build_volumes_and_mounts(
         config_map_name,
         "backup.yaml",
         &cluster.name,
+        cluster.tls_enabled,
         auth,
         &backup.spec.storage,
     );
+    env.push(job_name_env_var("BACKUP_ID"));
 
     // Build container
     let container = Container {
@@ -52,6 +54,7 @@ pub fn build_backup_job(
             "--config".to_string(),
             "/config/backup.yaml".to_string(),
         ]),
+        env: if env.is_empty() { None } else { Some(env) },
         volume_mounts: Some(volume_mounts),
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
@@ -124,6 +127,7 @@ mod tests {
             },
             authentication: None,
             topics: None,
+            connection: None,
             consumer_groups: None,
             storage: StorageSpec {
                 storage_type: StorageType::S3,
@@ -133,15 +137,21 @@ mod tests {
                     prefix: None,
                     endpoint: None,
                     force_path_style: None,
+                    allow_http: None,
                     credentials_secret: Some(SecretKeyRef {
                         name: "aws-creds".to_string(),
                         key: "credentials".to_string(),
                     }),
+                    access_key_secret: None,
+                    secret_key_secret: None,
                 }),
                 azure: None,
                 gcs: None,
+                filesystem: None,
             },
             backup: None,
+            metrics: None,
+            offset_storage: None,
             schedule: None,
             retention: None,
             resources: None,

--- a/src/jobs/cronjob.rs
+++ b/src/jobs/cronjob.rs
@@ -10,7 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    apply_pod_template, build_labels, build_volumes_and_mounts, merge_template_labels,
+    apply_pod_template, build_labels, build_volumes_and_mounts, job_name_env_var,
+    merge_template_labels,
 };
 
 /// Build a Kubernetes CronJob for scheduled backups
@@ -35,13 +36,15 @@ pub fn build_backup_cronjob(
     merge_template_labels(&mut labels, backup.spec.template.as_ref());
 
     // Build volumes and mounts
-    let (volumes, volume_mounts) = build_volumes_and_mounts(
+    let (volumes, volume_mounts, mut env) = build_volumes_and_mounts(
         config_map_name,
         "backup.yaml",
         &cluster.name,
+        cluster.tls_enabled,
         auth,
         &backup.spec.storage,
     );
+    env.push(job_name_env_var("BACKUP_ID"));
 
     // Build container
     let container = Container {
@@ -53,6 +56,7 @@ pub fn build_backup_cronjob(
             "--config".to_string(),
             "/config/backup.yaml".to_string(),
         ]),
+        env: if env.is_empty() { None } else { Some(env) },
         volume_mounts: Some(volume_mounts),
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()

--- a/src/jobs/restore_job.rs
+++ b/src/jobs/restore_job.rs
@@ -39,10 +39,11 @@ pub fn build_restore_job(
     let annotations = build_annotations(restore.spec.template.as_ref());
 
     // Build volumes and mounts — use source backup's storage config for credentials
-    let (volumes, volume_mounts) = build_volumes_and_mounts(
+    let (volumes, volume_mounts, env) = build_volumes_and_mounts(
         config_map_name,
         "restore.yaml",
         &cluster.name,
+        cluster.tls_enabled,
         auth,
         &source_backup.spec.storage,
     );
@@ -57,6 +58,7 @@ pub fn build_restore_job(
             "--config".to_string(),
             "/config/restore.yaml".to_string(),
         ]),
+        env: if env.is_empty() { None } else { Some(env) },
         volume_mounts: Some(volume_mounts),
         resources: restore.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
-    ConfigMapVolumeSource, KeyToPath, PodSpec, SecretVolumeSource, Volume, VolumeMount,
+    ConfigMapVolumeSource, EnvVar, EnvVarSource, KeyToPath, ObjectFieldSelector, PodSpec,
+    SecretKeySelector, SecretVolumeSource, Volume, VolumeMount,
 };
 
-use crate::crd::common::{PodTemplateSpec as CrdPodTemplate, StorageSpec, StorageType};
+use crate::crd::common::{
+    PodTemplateSpec as CrdPodTemplate, SecretKeyRef, StorageSpec, StorageType,
+};
 use crate::strimzi::kafka_user::ResolvedAuth;
 use crate::strimzi::tls;
 
@@ -38,11 +41,13 @@ pub fn build_volumes_and_mounts(
     config_map_name: &str,
     _config_key: &str,
     cluster_name: &str,
+    tls_enabled: bool,
     auth: &ResolvedAuth,
     storage: &StorageSpec,
-) -> (Vec<Volume>, Vec<VolumeMount>) {
+) -> (Vec<Volume>, Vec<VolumeMount>, Vec<EnvVar>) {
     let mut volumes = Vec::new();
     let mut mounts = Vec::new();
+    let mut env = Vec::new();
 
     // Config volume (from ConfigMap)
     volumes.push(Volume {
@@ -61,26 +66,28 @@ pub fn build_volumes_and_mounts(
     });
 
     // Cluster CA certificate volume
-    let ca_secret = tls::cluster_ca_secret_name(cluster_name);
-    volumes.push(Volume {
-        name: "cluster-ca".to_string(),
-        secret: Some(SecretVolumeSource {
-            secret_name: Some(ca_secret),
-            items: Some(vec![KeyToPath {
-                key: "ca.crt".to_string(),
-                path: "ca.crt".to_string(),
+    if tls_enabled || matches!(auth, ResolvedAuth::Tls { .. }) {
+        let ca_secret = tls::cluster_ca_secret_name(cluster_name);
+        volumes.push(Volume {
+            name: "cluster-ca".to_string(),
+            secret: Some(SecretVolumeSource {
+                secret_name: Some(ca_secret),
+                items: Some(vec![KeyToPath {
+                    key: "ca.crt".to_string(),
+                    path: "ca.crt".to_string(),
+                    ..Default::default()
+                }]),
                 ..Default::default()
-            }]),
+            }),
             ..Default::default()
-        }),
-        ..Default::default()
-    });
-    mounts.push(VolumeMount {
-        name: "cluster-ca".to_string(),
-        mount_path: "/certs/cluster-ca".to_string(),
-        read_only: Some(true),
-        ..Default::default()
-    });
+        });
+        mounts.push(VolumeMount {
+            name: "cluster-ca".to_string(),
+            mount_path: "/certs/cluster-ca".to_string(),
+            read_only: Some(true),
+            ..Default::default()
+        });
+    }
 
     // User credentials volume (TLS or SCRAM)
     match auth {
@@ -105,6 +112,11 @@ pub fn build_volumes_and_mounts(
             password_key,
             ..
         } => {
+            env.push(secret_env_var(
+                "KAFKA_SASL_PASSWORD",
+                secret_name,
+                password_key,
+            ));
             volumes.push(Volume {
                 name: "user-certs".to_string(),
                 secret: Some(SecretVolumeSource {
@@ -129,50 +141,148 @@ pub fn build_volumes_and_mounts(
     }
 
     // Storage credentials volume
-    let cred_secret = get_credentials_secret_name(storage);
-    if let Some((secret_name, secret_key)) = cred_secret {
-        volumes.push(Volume {
-            name: "storage-credentials".to_string(),
-            secret: Some(SecretVolumeSource {
-                secret_name: Some(secret_name),
-                items: Some(vec![KeyToPath {
-                    key: secret_key,
-                    path: "credentials".to_string(),
-                    ..Default::default()
-                }]),
+    add_storage_credentials(storage, &mut volumes, &mut mounts, &mut env);
+
+    (volumes, mounts, env)
+}
+
+/// Build an env var whose value is the owning Job name.
+pub fn job_name_env_var(name: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value_from: Some(EnvVarSource {
+            field_ref: Some(ObjectFieldSelector {
+                field_path: "metadata.labels['batch.kubernetes.io/job-name']".to_string(),
                 ..Default::default()
             }),
             ..Default::default()
-        });
-        mounts.push(VolumeMount {
-            name: "storage-credentials".to_string(),
-            mount_path: "/credentials".to_string(),
-            read_only: Some(true),
-            ..Default::default()
-        });
+        }),
+        ..Default::default()
     }
-
-    (volumes, mounts)
 }
 
-/// Get the storage credentials secret name if configured
-fn get_credentials_secret_name(storage: &StorageSpec) -> Option<(String, String)> {
+fn add_storage_credentials(
+    storage: &StorageSpec,
+    volumes: &mut Vec<Volume>,
+    mounts: &mut Vec<VolumeMount>,
+    env: &mut Vec<EnvVar>,
+) {
     match storage.storage_type {
-        StorageType::S3 => storage
-            .s3
-            .as_ref()
-            .and_then(|s| s.credentials_secret.as_ref())
-            .map(|s| (s.name.clone(), s.key.clone())),
-        StorageType::Azure => storage
-            .azure
-            .as_ref()
-            .and_then(|a| a.credentials_secret.as_ref())
-            .map(|s| (s.name.clone(), s.key.clone())),
-        StorageType::Gcs => storage
-            .gcs
-            .as_ref()
-            .and_then(|g| g.credentials_secret.as_ref())
-            .map(|s| (s.name.clone(), s.key.clone())),
+        StorageType::S3 => {
+            if let Some(s3) = &storage.s3 {
+                if let Some(secret) = &s3.access_key_secret {
+                    env.push(secret_env_var(
+                        "AWS_ACCESS_KEY_ID",
+                        &secret.name,
+                        &secret.key,
+                    ));
+                }
+                if let Some(secret) = &s3.secret_key_secret {
+                    env.push(secret_env_var(
+                        "AWS_SECRET_ACCESS_KEY",
+                        &secret.name,
+                        &secret.key,
+                    ));
+                }
+                if let Some(secret) = &s3.credentials_secret {
+                    add_credentials_file_volume(secret, volumes, mounts);
+                    env.push(static_env_var(
+                        "AWS_SHARED_CREDENTIALS_FILE",
+                        "/credentials/credentials",
+                    ));
+                }
+            }
+        }
+        StorageType::Azure => {
+            if let Some(azure) = &storage.azure {
+                if let Some(secret) = azure
+                    .account_key_secret
+                    .as_ref()
+                    .or(azure.credentials_secret.as_ref())
+                {
+                    env.push(secret_env_var(
+                        "AZURE_STORAGE_KEY",
+                        &secret.name,
+                        &secret.key,
+                    ));
+                }
+                if let Some(secret) = &azure.sas_token_secret {
+                    env.push(secret_env_var(
+                        "AZURE_STORAGE_SAS_TOKEN",
+                        &secret.name,
+                        &secret.key,
+                    ));
+                }
+                if let Some(secret) = &azure.client_secret_secret {
+                    env.push(secret_env_var(
+                        "AZURE_CLIENT_SECRET",
+                        &secret.name,
+                        &secret.key,
+                    ));
+                }
+            }
+        }
+        StorageType::Gcs => {
+            if let Some(gcs) = &storage.gcs {
+                if let Some(secret) = &gcs.credentials_secret {
+                    add_credentials_file_volume(secret, volumes, mounts);
+                    env.push(static_env_var(
+                        "GOOGLE_APPLICATION_CREDENTIALS",
+                        "/credentials/credentials",
+                    ));
+                }
+            }
+        }
+        StorageType::Filesystem => {}
+    }
+}
+
+fn add_credentials_file_volume(
+    secret: &SecretKeyRef,
+    volumes: &mut Vec<Volume>,
+    mounts: &mut Vec<VolumeMount>,
+) {
+    volumes.push(Volume {
+        name: "storage-credentials".to_string(),
+        secret: Some(SecretVolumeSource {
+            secret_name: Some(secret.name.clone()),
+            items: Some(vec![KeyToPath {
+                key: secret.key.clone(),
+                path: "credentials".to_string(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    mounts.push(VolumeMount {
+        name: "storage-credentials".to_string(),
+        mount_path: "/credentials".to_string(),
+        read_only: Some(true),
+        ..Default::default()
+    });
+}
+
+fn secret_env_var(name: &str, secret_name: &str, secret_key: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value_from: Some(EnvVarSource {
+            secret_key_ref: Some(SecretKeySelector {
+                name: secret_name.to_string(),
+                key: secret_key.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn static_env_var(name: &str, value: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value: Some(value.to_string()),
+        ..Default::default()
     }
 }
 

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -17,6 +17,7 @@ fn sample_backup() -> KafkaBackup {
             include: vec!["orders.*".to_string(), "payments.*".to_string()],
             exclude: vec!["__.*".to_string()],
         }),
+        connection: None,
         consumer_groups: None,
         storage: StorageSpec {
             storage_type: StorageType::S3,
@@ -26,20 +27,39 @@ fn sample_backup() -> KafkaBackup {
                 prefix: Some("strimzi/production-cluster/".to_string()),
                 endpoint: None,
                 force_path_style: None,
+                allow_http: None,
                 credentials_secret: Some(SecretKeyRef {
                     name: "backup-s3-credentials".to_string(),
                     key: "aws-credentials".to_string(),
                 }),
+                access_key_secret: None,
+                secret_key_secret: None,
             }),
             azure: None,
             gcs: None,
+            filesystem: None,
         },
         backup: Some(BackupOptionsSpec {
             compression: Some("zstd".to_string()),
+            compression_level: None,
             encryption: None,
             segment_size: Some(268435456),
+            segment_max_interval_ms: None,
             parallelism: Some(4),
+            start_offset: None,
+            continuous: None,
+            include_internal_topics: None,
+            internal_topics: Vec::new(),
+            checkpoint_interval_secs: None,
+            sync_interval_secs: None,
+            include_offset_headers: None,
+            source_cluster_id: None,
+            stop_at_current_offsets: None,
+            poll_interval_ms: None,
+            consumer_group_snapshot: None,
         }),
+        metrics: None,
+        offset_storage: None,
         schedule: Some(ScheduleSpec {
             cron: "0 2 * * *".to_string(),
             timezone: Some("UTC".to_string()),
@@ -79,7 +99,11 @@ fn test_backup_config_generation() {
     let yaml = build_backup_config_yaml(&backup, &cluster, &None, &ResolvedAuth::None).unwrap();
 
     assert!(yaml.contains("mode: backup"));
-    assert!(yaml.contains("bootstrap_servers: production-cluster-kafka-bootstrap.kafka.svc:9093"));
+    assert!(yaml.contains("backup_id: ${BACKUP_ID}"));
+    assert!(yaml.contains("bootstrap_servers:"));
+    assert!(yaml.contains("- production-cluster-kafka-bootstrap.kafka.svc:9093"));
+    assert!(yaml.contains("security_protocol: SSL"));
+    assert!(yaml.contains("backend: s3"));
     assert!(yaml.contains("compression: zstd"));
     assert!(yaml.contains("orders.*"));
     assert!(yaml.contains("payments.*"));
@@ -131,6 +155,12 @@ fn test_backup_job_creation() {
         .as_ref()
         .unwrap()
         .contains(&"/config/backup.yaml".to_string()));
+    assert!(pod_spec.containers[0]
+        .env
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|env| env.name == "BACKUP_ID"));
 }
 
 #[test]
@@ -152,8 +182,9 @@ fn test_backup_with_tls_auth() {
     };
 
     let yaml = build_backup_config_yaml(&backup, &cluster, &None, &auth).unwrap();
-    assert!(yaml.contains("type: tls"));
-    assert!(yaml.contains("cert_path: /certs/user/user.crt"));
+    assert!(yaml.contains("security_protocol: SSL"));
+    assert!(yaml.contains("ssl_certificate_location: /certs/user/user.crt"));
+    assert!(yaml.contains("ssl_key_location: /certs/user/user.key"));
 
     let job = build_backup_job(&backup, "test-job", "test-config", &cluster, &auth).unwrap();
 

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -15,6 +15,7 @@ fn sample_backup() -> KafkaBackup {
         },
         authentication: None,
         topics: None,
+        connection: None,
         consumer_groups: None,
         storage: StorageSpec {
             storage_type: StorageType::S3,
@@ -24,15 +25,21 @@ fn sample_backup() -> KafkaBackup {
                 prefix: Some("strimzi/production-cluster/".to_string()),
                 endpoint: None,
                 force_path_style: None,
+                allow_http: None,
                 credentials_secret: Some(SecretKeyRef {
                     name: "backup-s3-credentials".to_string(),
                     key: "aws-credentials".to_string(),
                 }),
+                access_key_secret: None,
+                secret_key_secret: None,
             }),
             azure: None,
             gcs: None,
+            filesystem: None,
         },
         backup: None,
+        metrics: None,
+        offset_storage: None,
         schedule: None,
         retention: None,
         resources: None,
@@ -56,9 +63,11 @@ fn sample_restore() -> KafkaRestore {
             backup_id: Some("backup-20260213-020000".to_string()),
         },
         point_in_time: Some(PointInTimeSpec {
+            start_timestamp: None,
             timestamp: Some("2026-02-13T01:30:00.000Z".to_string()),
             offset_from_end: None,
         }),
+        connection: None,
         topic_mapping: vec![
             TopicMappingEntry {
                 source_topic: "orders".to_string(),
@@ -71,6 +80,10 @@ fn sample_restore() -> KafkaRestore {
         ],
         consumer_groups: Some(ConsumerGroupRestoreSpec {
             restore: true,
+            auto: None,
+            groups: Vec::new(),
+            strategy: None,
+            offset_report: None,
             mapping: vec![ConsumerGroupMapping {
                 source_group: "order-processor".to_string(),
                 target_group: "order-processor".to_string(),
@@ -78,9 +91,24 @@ fn sample_restore() -> KafkaRestore {
         }),
         restore: Some(RestoreOptionsSpec {
             topic_creation: Some(TopicCreationPolicy::Auto),
-            existing_topic_policy: Some(ExistingTopicPolicy::Fail),
+            existing_topic_policy: Some(ExistingTopicPolicy::Append),
+            dry_run: None,
+            include_original_offset_header: None,
+            source_partitions: Vec::new(),
+            partition_mapping: Vec::new(),
             parallelism: Some(4),
+            rate_limit_records_per_sec: None,
+            rate_limit_bytes_per_sec: None,
+            produce_batch_size: None,
+            produce_acks: None,
+            produce_timeout_ms: None,
+            checkpoint_state: None,
+            checkpoint_interval_secs: None,
+            default_replication_factor: None,
+            repartitioning: Vec::new(),
+            purge_topics: None,
         }),
+        metrics: None,
         resources: None,
         template: None,
         image: None,
@@ -113,7 +141,10 @@ fn test_restore_config_generation() {
 
     assert!(yaml.contains("mode: restore"));
     assert!(yaml.contains("backup_id: backup-20260213-020000"));
-    assert!(yaml.contains("bootstrap_servers: dr-cluster-kafka-bootstrap.kafka.svc:9093"));
+    assert!(yaml.contains("bootstrap_servers:"));
+    assert!(yaml.contains("- dr-cluster-kafka-bootstrap.kafka.svc:9093"));
+    assert!(yaml.contains("security_protocol: SSL"));
+    assert!(yaml.contains("backend: s3"));
     assert!(yaml.contains("orders: orders-restored"));
     assert!(yaml.contains("payments: payments-restored"));
     // PITR timestamp should be converted to epoch ms
@@ -170,6 +201,7 @@ fn test_restore_job_creation() {
 fn test_restore_with_offset_from_end() {
     let mut restore = sample_restore();
     restore.spec.point_in_time = Some(PointInTimeSpec {
+        start_timestamp: None,
         timestamp: None,
         offset_from_end: Some("2h".to_string()),
     });
@@ -177,8 +209,26 @@ fn test_restore_with_offset_from_end() {
     let backup = sample_backup();
     let cluster = sample_cluster();
 
-    let yaml =
-        build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+    let err = build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None)
+        .unwrap_err();
 
-    assert!(yaml.contains("offset_from_end: 2h"));
+    assert!(err
+        .to_string()
+        .contains("pointInTime.offsetFromEnd is not supported"));
+}
+
+#[test]
+fn test_restore_with_unsupported_existing_topic_fail_policy() {
+    let mut restore = sample_restore();
+    restore.spec.restore.as_mut().unwrap().existing_topic_policy = Some(ExistingTopicPolicy::Fail);
+
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let err = build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None)
+        .unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("existingTopicPolicy: fail is not supported"));
 }


### PR DESCRIPTION
## Summary
- expand KafkaBackup/KafkaRestore CRDs to expose current kafka-backup core config options
- update config adapters to emit core-compatible YAML for security, storage, metrics, backup, and restore options
- wire backup IDs through the Job name, update credential env/mount handling, regenerate deploy and Helm CRDs, and refresh examples/docs
- reject unsupported legacy fields instead of silently ignoring them

## Verification
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
- confirmed deploy CRDs match Helm CRD copies