### PR TITLE
feat: add incremental backup support via offset_storage

### DIFF
--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -23,10 +23,23 @@ pub fn build_backup_config_yaml(
         Value::String("backup".to_string()),
     );
 
-    // Backup ID is provided by the job pod via env var so scheduled jobs get unique IDs.
+    // Backup ID: incremental backups require a stable id across runs so the CLI can
+    // merge manifests and resume from the last saved offset (kafka-backup >= v0.13.5).
+    // We infer "incremental" from the same predicate the CLI itself uses —
+    // `offset_storage` is set and `continuous` is not `true`. In all other cases we
+    // keep the env-var form so scheduled jobs get a unique id per run.
+    let backup_id = if is_incremental_one_shot(backup) {
+        backup
+            .metadata
+            .name
+            .clone()
+            .unwrap_or_else(|| "backup".to_string())
+    } else {
+        "${BACKUP_ID}".to_string()
+    };
     config.insert(
         Value::String("backup_id".to_string()),
-        Value::String("${BACKUP_ID}".to_string()),
+        Value::String(backup_id),
     );
 
     // Source (Kafka cluster)
@@ -377,6 +390,24 @@ fn build_offset_storage_options(offset_storage: &crate::crd::common::OffsetStora
     Value::Mapping(config)
 }
 
+/// Whether this backup will behave as an incremental one-shot run.
+///
+/// Mirrors the predicate in kafka-backup's `should_create_offset_store`: the offset
+/// store is used when an `offset_storage` block is configured, or when
+/// `backup.continuous` is `true`. When the former is true but the latter is not,
+/// each run is a one-shot that resumes from the previous run — which requires a
+/// stable `backup_id` across runs so the CLI can merge manifests.
+fn is_incremental_one_shot(backup: &KafkaBackup) -> bool {
+    let offset_storage_set = backup.spec.offset_storage.is_some();
+    let continuous = backup
+        .spec
+        .backup
+        .as_ref()
+        .and_then(|b| b.continuous)
+        .unwrap_or(false);
+    offset_storage_set && !continuous
+}
+
 fn insert_bool(config: &mut serde_yaml::Mapping, key: &str, value: Option<bool>) {
     if let Some(value) = value {
         config.insert(Value::String(key.to_string()), Value::Bool(value));
@@ -469,21 +500,75 @@ mod tests {
         backup
     }
 
-    #[test]
-    fn test_build_backup_config() {
-        let backup = test_backup();
-        let cluster = ResolvedKafkaCluster {
+    fn test_cluster() -> ResolvedKafkaCluster {
+        ResolvedKafkaCluster {
             name: "my-cluster".to_string(),
             namespace: "kafka".to_string(),
             bootstrap_servers: "my-cluster-kafka-bootstrap.kafka.svc:9093".to_string(),
             replicas: 3,
             tls_enabled: true,
             listener_name: "tls".to_string(),
-        };
+        }
+    }
 
-        let yaml = build_backup_config_yaml(&backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+    #[test]
+    fn test_build_backup_config() {
+        let backup = test_backup();
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
         assert!(yaml.contains("mode: backup"));
         assert!(yaml.contains("bootstrap_servers:"));
         assert!(yaml.contains("orders.*"));
+    }
+
+    #[test]
+    fn test_default_backup_id_uses_env_var() {
+        let backup = test_backup();
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("backup_id: ${BACKUP_ID}"));
+    }
+
+    #[test]
+    fn test_incremental_one_shot_uses_stable_backup_id() {
+        let mut backup = test_backup();
+        backup.spec.offset_storage = Some(OffsetStorageSpec {
+            backend: None,
+            db_path: Some("/tmp/offsets.db".to_string()),
+            s3_key: None,
+            sync_interval_secs: Some(30),
+        });
+        // continuous is None (defaults to false) → incremental one-shot
+
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("backup_id: test-backup\n"));
+        assert!(!yaml.contains("${BACKUP_ID}"));
+        assert!(yaml.contains("offset_storage:"));
+    }
+
+    #[test]
+    fn test_continuous_mode_keeps_env_var_backup_id() {
+        let mut backup = test_backup();
+        backup.spec.offset_storage = Some(OffsetStorageSpec {
+            backend: None,
+            db_path: Some("/tmp/offsets.db".to_string()),
+            s3_key: None,
+            sync_interval_secs: None,
+        });
+        backup.spec.backup.as_mut().unwrap().continuous = Some(true);
+
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("backup_id: ${BACKUP_ID}"));
+    }
+
+    #[test]
+    fn test_offset_storage_absent_keeps_env_var_backup_id() {
+        let backup = test_backup();
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("backup_id: ${BACKUP_ID}"));
+        assert!(!yaml.contains("offset_storage:"));
     }
 }

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -8,5 +8,7 @@ pub const FINALIZER: &str = "kafkabackup.com/cleanup";
 pub const TRIGGER_ANNOTATION: &str = "kafkabackup.com/trigger";
 pub const TRIGGER_VALUE_NOW: &str = "now";
 
-/// Default backup image
-pub const DEFAULT_BACKUP_IMAGE: &str = "ghcr.io/osodevops/kafka-backup:latest";
+/// Default backup image. Pinned to a specific version so behaviour is deterministic —
+/// v0.13.5 is the first release that activates incremental one-shot backups from an
+/// `offset_storage` block alone (see kafka-backup PR #92).
+pub const DEFAULT_BACKUP_IMAGE: &str = "ghcr.io/osodevops/kafka-backup:v0.13.5";

--- a/src/retention/policy.rs
+++ b/src/retention/policy.rs
@@ -17,7 +17,7 @@ pub fn evaluate_retention(
 
     // Sort by start_time descending (newest first)
     let mut sorted: Vec<&BackupHistoryEntry> = history.iter().collect();
-    sorted.sort_by(|a, b| b.start_time.cmp(&a.start_time));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.start_time));
 
     // Apply max_backups limit
     if let Some(max_backups) = retention.max_backups {


### PR DESCRIPTION
## Summary

Wires the operator to [kafka-backup v0.13.5](https://github.com/osodevops/kafka-backup/releases/tag/v0.13.5)'s incremental one-shot backup fix (osodevops/kafka-backup#92). Addresses #5.

The recent CRD alignment on `main` already exposes `spec.offset_storage` and `spec.backup.continuous`, so no new CRD surface is needed. The one remaining gap is the backup id: the generator emits `${BACKUP_ID}` for every run, which is resolved from the K8s Job name and is therefore always unique per run. That defeats the CLI's cross-run manifest merging and makes incremental impossible.

This PR closes that gap with a minimal predicate change:

- If `spec.offset_storage` is set **and** `spec.backup.continuous != true`, emit the CR name as `backup_id`. This is the same predicate the CLI uses in its `should_create_offset_store(continuous, offset_storage.is_some())` gate — so whenever the CLI activates its offset store, we give it a stable id to resume against.
- Otherwise: preserve the existing `${BACKUP_ID}` behaviour (full snapshots + continuous mode both keep getting unique per-run ids).

Also pins `DEFAULT_BACKUP_IMAGE` to `ghcr.io/osodevops/kafka-backup:v0.13.5` so the fix is actually present at runtime.

## Usage

```yaml
apiVersion: kafkabackup.com/v1alpha1
kind: KafkaBackup
spec:
  strimziClusterRef: { name: my-cluster }
  storage: { type: s3, s3: { bucket: ... } }
  schedule: { cron: "0 * * * *" }
  offsetStorage:
    sync_interval_secs: 30    # presence of this block turns on incremental
```

## What is intentionally NOT in this PR

- **Retention for incremental chains.** One `backup_id` is now a growing chain of merged manifests, so "delete whole backup" retention doesn't map cleanly. Chain rotation (e.g. `chainRotation: 7d` starting a fresh backup_id on an interval) can follow as a separate PR.
- **Automatic `/state` volume.** The CLI defaults `offset_storage.db_path` to `$TMPDIR`, which is writable inside a pod. Users wanting a persistent mount can set `db_path` and configure the PVC via `spec.template`.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 24 passed (17 lib + 7 integration), including new coverage for:
  - default path still emits `backup_id: ${BACKUP_ID}`
  - incremental one-shot (`offset_storage` set, `continuous` unset) emits `backup_id: <cr-name>`
  - continuous mode keeps `${BACKUP_ID}` even when `offset_storage` is set
  - no `offset_storage` block is emitted when the CR doesn't set one
- [ ] Manual e2e against a real Strimzi cluster: two consecutive scheduled runs produce a merged manifest with new segments only.

Resolves #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)