### PR TITLE
docs: fix helm install command in README (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ helm repo add oso-devops https://osodevops.github.io/helm-charts/
 helm repo update
 
 # Install the operator
-helm install kafka-backup-operator oso-devops/kafka-backup-operator \
+helm install strimzi-backup-operator oso-devops/strimzi-backup-operator \
   --namespace kafka \
   --create-namespace
 ```


### PR DESCRIPTION
## Summary

- The README's \`helm install\` snippet pointed to \`oso-devops/kafka-backup-operator\`, which resolves to a **different project** (\`osodevops/kafka-backup-operator\`, API group \`kafka.oso.sh\`) in the shared \`osodevops/helm-charts\` repository.
- This project's chart is published as \`strimzi-backup-operator\` — the install command now matches that.

Users following the old snippet would install the wrong operator, which almost certainly contributed to the confusion reported in issue #7 (the user's CRD uses \`apiVersion: kafka.oso.sh/v1alpha1\` and \`kafkaCluster\` / \`caSecret\` fields that belong to the other project).

## Test plan

- [ ] \`helm repo add oso-devops https://osodevops.github.io/helm-charts/ && helm repo update\`
- [ ] \`helm search repo oso-devops/strimzi-backup-operator\` returns this chart
- [ ] \`helm install strimzi-backup-operator oso-devops/strimzi-backup-operator --namespace kafka --create-namespace\` installs the operator shipped from this repo

## Follow-ups (out of scope here)

- The local chart in \`deploy/helm/kafka-backup-operator/\` is still named \`kafka-backup-operator\`, and \`.github/workflows/sync-helm-chart.yaml\` syncs to \`charts/kafka-backup-operator\` in \`osodevops/helm-charts\` — that path is already occupied by the other project. The internal chart and the sync workflow should be renamed to \`strimzi-backup-operator\` so that future releases sync to the correct destination and the published chart stays in step with this repo.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)