### PR TITLE
feat: support custom CA secret override on strimziClusterRef

### DIFF
--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -580,6 +580,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -378,6 +378,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the target Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/deploy/helm/kafka-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/kafka-backup-operator/crds/kafkabackups.yaml
@@ -580,6 +580,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/deploy/helm/kafka-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/kafka-backup-operator/crds/kafkarestores.yaml
@@ -378,6 +378,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the target Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -443,6 +443,7 @@ mod tests {
             strimzi_cluster_ref: StrimziClusterRef {
                 name: "my-cluster".to_string(),
                 namespace: None,
+                ca_secret: None,
             },
             authentication: None,
             topics: Some(TopicSelection {

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -54,6 +54,12 @@ pub struct StrimziClusterRef {
     /// Namespace of the Kafka CR (defaults to same namespace as this resource)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+    /// Optional override for the cluster CA secret. Defaults to the Strimzi
+    /// convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the
+    /// CA is stored in a differently-named secret, or when the key inside the
+    /// secret is not `ca.crt`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ca_secret: Option<SecretKeyRef>,
 }
 
 /// Authentication configuration for connecting to Kafka

--- a/src/jobs/backup_job.rs
+++ b/src/jobs/backup_job.rs
@@ -41,6 +41,7 @@ pub fn build_backup_job(
         cluster.tls_enabled,
         auth,
         &backup.spec.storage,
+        backup.spec.strimzi_cluster_ref.ca_secret.as_ref(),
     );
     env.push(job_name_env_var("BACKUP_ID"));
 
@@ -124,6 +125,7 @@ mod tests {
             strimzi_cluster_ref: StrimziClusterRef {
                 name: "my-cluster".to_string(),
                 namespace: None,
+                ca_secret: None,
             },
             authentication: None,
             topics: None,

--- a/src/jobs/cronjob.rs
+++ b/src/jobs/cronjob.rs
@@ -43,6 +43,7 @@ pub fn build_backup_cronjob(
         cluster.tls_enabled,
         auth,
         &backup.spec.storage,
+        backup.spec.strimzi_cluster_ref.ca_secret.as_ref(),
     );
     env.push(job_name_env_var("BACKUP_ID"));
 

--- a/src/jobs/restore_job.rs
+++ b/src/jobs/restore_job.rs
@@ -46,6 +46,7 @@ pub fn build_restore_job(
         cluster.tls_enabled,
         auth,
         &source_backup.spec.storage,
+        restore.spec.strimzi_cluster_ref.ca_secret.as_ref(),
     );
 
     // Build container

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -36,7 +36,12 @@ pub fn build_labels(cr_name: &str, cluster_name: &str, job_type: &str) -> BTreeM
     labels
 }
 
-/// Build the volumes and volume mounts for backup/restore containers
+/// Build the volumes and volume mounts for backup/restore containers.
+///
+/// `ca_override` swaps out the Strimzi-convention cluster CA secret
+/// (`{cluster}-cluster-ca-cert` / `ca.crt`) for a user-provided one. The file
+/// is always mounted at `/certs/cluster-ca/ca.crt` regardless of the source
+/// key, so the config YAML path (`ssl_ca_location`) stays constant.
 pub fn build_volumes_and_mounts(
     config_map_name: &str,
     _config_key: &str,
@@ -44,6 +49,7 @@ pub fn build_volumes_and_mounts(
     tls_enabled: bool,
     auth: &ResolvedAuth,
     storage: &StorageSpec,
+    ca_override: Option<&SecretKeyRef>,
 ) -> (Vec<Volume>, Vec<VolumeMount>, Vec<EnvVar>) {
     let mut volumes = Vec::new();
     let mut mounts = Vec::new();
@@ -67,13 +73,13 @@ pub fn build_volumes_and_mounts(
 
     // Cluster CA certificate volume
     if tls_enabled || matches!(auth, ResolvedAuth::Tls { .. }) {
-        let ca_secret = tls::cluster_ca_secret_name(cluster_name);
+        let (ca_secret, ca_key) = tls::ca_secret_ref(cluster_name, ca_override);
         volumes.push(Volume {
             name: "cluster-ca".to_string(),
             secret: Some(SecretVolumeSource {
                 secret_name: Some(ca_secret),
                 items: Some(vec![KeyToPath {
-                    key: "ca.crt".to_string(),
+                    key: ca_key,
                     path: "ca.crt".to_string(),
                     ..Default::default()
                 }]),
@@ -374,5 +380,80 @@ pub fn merge_template_labels(
                 labels.extend(meta.labels.clone());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::common::{StorageSpec, StorageType};
+
+    fn empty_storage() -> StorageSpec {
+        StorageSpec {
+            storage_type: StorageType::Filesystem,
+            s3: None,
+            azure: None,
+            gcs: None,
+            filesystem: None,
+        }
+    }
+
+    #[test]
+    fn cluster_ca_volume_uses_override_secret_and_key() {
+        let override_ref = SecretKeyRef {
+            name: "custom-ca".to_string(),
+            key: "tls.crt".to_string(),
+        };
+        let (volumes, mounts, _env) = build_volumes_and_mounts(
+            "cm",
+            "backup.yaml",
+            "my-cluster",
+            true,
+            &ResolvedAuth::None,
+            &empty_storage(),
+            Some(&override_ref),
+        );
+
+        let ca_volume = volumes
+            .iter()
+            .find(|v| v.name == "cluster-ca")
+            .expect("cluster-ca volume should be present");
+        let secret = ca_volume.secret.as_ref().expect("secret volume source");
+        assert_eq!(secret.secret_name.as_deref(), Some("custom-ca"));
+        let items = secret.items.as_ref().expect("secret items");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].key, "tls.crt");
+        assert_eq!(items[0].path, "ca.crt");
+
+        let ca_mount = mounts
+            .iter()
+            .find(|m| m.name == "cluster-ca")
+            .expect("cluster-ca mount should be present");
+        assert_eq!(ca_mount.mount_path, "/certs/cluster-ca");
+    }
+
+    #[test]
+    fn cluster_ca_volume_defaults_to_strimzi_convention() {
+        let (volumes, _mounts, _env) = build_volumes_and_mounts(
+            "cm",
+            "backup.yaml",
+            "my-cluster",
+            true,
+            &ResolvedAuth::None,
+            &empty_storage(),
+            None,
+        );
+
+        let ca_volume = volumes
+            .iter()
+            .find(|v| v.name == "cluster-ca")
+            .expect("cluster-ca volume should be present");
+        let secret = ca_volume.secret.as_ref().expect("secret volume source");
+        assert_eq!(
+            secret.secret_name.as_deref(),
+            Some("my-cluster-cluster-ca-cert")
+        );
+        let items = secret.items.as_ref().expect("secret items");
+        assert_eq!(items[0].key, "ca.crt");
     }
 }

--- a/src/reconcilers/backup.rs
+++ b/src/reconcilers/backup.rs
@@ -62,7 +62,14 @@ pub async fn reconcile_backup(
         };
 
     // Step 2: Resolve TLS certificates
-    let tls_certs = match resolve_cluster_ca(&client, &kafka_cluster.name, &namespace).await {
+    let tls_certs = match resolve_cluster_ca(
+        &client,
+        &kafka_cluster.name,
+        backup.spec.strimzi_cluster_ref.ca_secret.as_ref(),
+        &namespace,
+    )
+    .await
+    {
         Ok(certs) => Some(certs),
         Err(e) => {
             warn!(%name, error = %e, "Failed to resolve TLS certs (may not be required)");

--- a/src/reconcilers/restore.rs
+++ b/src/reconcilers/restore.rs
@@ -77,7 +77,14 @@ pub async fn reconcile_restore(
         };
 
     // Step 3: Resolve TLS certificates
-    let tls_certs = match resolve_cluster_ca(&client, &kafka_cluster.name, &namespace).await {
+    let tls_certs = match resolve_cluster_ca(
+        &client,
+        &kafka_cluster.name,
+        restore.spec.strimzi_cluster_ref.ca_secret.as_ref(),
+        &namespace,
+    )
+    .await
+    {
         Ok(certs) => Some(certs),
         Err(e) => {
             warn!(%name, error = %e, "Failed to resolve TLS certs for target cluster");

--- a/src/strimzi/tls.rs
+++ b/src/strimzi/tls.rs
@@ -92,7 +92,10 @@ pub fn extract_secret_string(secret: &Secret, key: &str, secret_name: &str) -> R
 pub fn ca_secret_ref(cluster_name: &str, ca_override: Option<&SecretKeyRef>) -> (String, String) {
     match ca_override {
         Some(r) => (r.name.clone(), r.key.clone()),
-        None => (cluster_ca_secret_name(cluster_name), DEFAULT_CA_KEY.to_string()),
+        None => (
+            cluster_ca_secret_name(cluster_name),
+            DEFAULT_CA_KEY.to_string(),
+        ),
     }
 }
 

--- a/src/strimzi/tls.rs
+++ b/src/strimzi/tls.rs
@@ -2,7 +2,11 @@ use k8s_openapi::api::core::v1::Secret;
 use kube::{Api, Client};
 use tracing::{debug, info};
 
+use crate::crd::common::SecretKeyRef;
 use crate::error::{Error, Result};
+
+/// Default key for the cluster CA certificate inside a Strimzi CA secret.
+pub const DEFAULT_CA_KEY: &str = "ca.crt";
 
 /// Resolved TLS certificates from Strimzi secrets
 #[derive(Clone, Debug)]
@@ -15,14 +19,17 @@ pub struct ResolvedTlsCerts {
     pub client_ca_cert: Option<String>,
 }
 
-/// Resolve Strimzi cluster CA certificate from the conventional secret name
+/// Resolve the cluster CA certificate. When `ca_override` is provided, the
+/// secret name and key come from the override; otherwise the operator falls
+/// back to the Strimzi convention (`{cluster}-cluster-ca-cert` / `ca.crt`).
 pub async fn resolve_cluster_ca(
     client: &Client,
     cluster_name: &str,
+    ca_override: Option<&SecretKeyRef>,
     namespace: &str,
 ) -> Result<ResolvedTlsCerts> {
-    let secret_name = format!("{cluster_name}-cluster-ca-cert");
-    info!(%secret_name, %namespace, "Resolving Strimzi cluster CA certificate");
+    let (secret_name, ca_key) = ca_secret_ref(cluster_name, ca_override);
+    info!(%secret_name, key = %ca_key, %namespace, "Resolving cluster CA certificate");
 
     let secrets: Api<Secret> = Api::namespaced(client.clone(), namespace);
 
@@ -34,15 +41,22 @@ pub async fn resolve_cluster_ca(
         _ => Error::Kube(e),
     })?;
 
-    let cluster_ca_cert = extract_secret_string(&ca_secret, "ca.crt", &secret_name)?;
+    let cluster_ca_cert = extract_secret_string(&ca_secret, &ca_key, &secret_name)?;
 
-    // Try to get client CA (may not exist)
-    let client_ca_name = format!("{cluster_name}-clients-ca-cert");
-    let client_ca_cert = match secrets.get(&client_ca_name).await {
-        Ok(client_secret) => extract_secret_string(&client_secret, "ca.crt", &client_ca_name).ok(),
-        Err(_) => {
-            debug!(%client_ca_name, "Client CA secret not found (optional)");
-            None
+    // Try to get client CA (may not exist). Only looked up when the caller
+    // didn't override the CA secret — an override implies a non-Strimzi layout.
+    let client_ca_cert = if ca_override.is_some() {
+        None
+    } else {
+        let client_ca_name = format!("{cluster_name}-clients-ca-cert");
+        match secrets.get(&client_ca_name).await {
+            Ok(client_secret) => {
+                extract_secret_string(&client_secret, DEFAULT_CA_KEY, &client_ca_name).ok()
+            }
+            Err(_) => {
+                debug!(%client_ca_name, "Client CA secret not found (optional)");
+                None
+            }
         }
     };
 
@@ -74,6 +88,14 @@ pub fn extract_secret_string(secret: &Secret, key: &str, secret_name: &str) -> R
     })
 }
 
+/// Resolve the CA secret name and key to read, honouring an optional override.
+pub fn ca_secret_ref(cluster_name: &str, ca_override: Option<&SecretKeyRef>) -> (String, String) {
+    match ca_override {
+        Some(r) => (r.name.clone(), r.key.clone()),
+        None => (cluster_ca_secret_name(cluster_name), DEFAULT_CA_KEY.to_string()),
+    }
+}
+
 /// Get the conventional Strimzi secret names for volume mounts
 pub fn cluster_ca_secret_name(cluster_name: &str) -> String {
     format!("{cluster_name}-cluster-ca-cert")
@@ -81,4 +103,27 @@ pub fn cluster_ca_secret_name(cluster_name: &str) -> String {
 
 pub fn clients_ca_secret_name(cluster_name: &str) -> String {
     format!("{cluster_name}-clients-ca-cert")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ca_secret_ref_defaults_to_strimzi_convention() {
+        let (name, key) = ca_secret_ref("my-cluster", None);
+        assert_eq!(name, "my-cluster-cluster-ca-cert");
+        assert_eq!(key, "ca.crt");
+    }
+
+    #[test]
+    fn ca_secret_ref_honours_override() {
+        let override_ref = SecretKeyRef {
+            name: "custom-ca".to_string(),
+            key: "tls.crt".to_string(),
+        };
+        let (name, key) = ca_secret_ref("my-cluster", Some(&override_ref));
+        assert_eq!(name, "custom-ca");
+        assert_eq!(key, "tls.crt");
+    }
 }

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -11,6 +11,7 @@ fn sample_backup() -> KafkaBackup {
         strimzi_cluster_ref: StrimziClusterRef {
             name: "production-cluster".to_string(),
             namespace: None,
+            ca_secret: None,
         },
         authentication: None,
         topics: Some(TopicSelection {

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -12,6 +12,7 @@ fn sample_backup() -> KafkaBackup {
         strimzi_cluster_ref: StrimziClusterRef {
             name: "production-cluster".to_string(),
             namespace: None,
+            ca_secret: None,
         },
         authentication: None,
         topics: None,
@@ -56,6 +57,7 @@ fn sample_restore() -> KafkaRestore {
         strimzi_cluster_ref: StrimziClusterRef {
             name: "dr-cluster".to_string(),
             namespace: None,
+            ca_secret: None,
         },
         authentication: None,
         backup_ref: BackupRef {


### PR DESCRIPTION
## Summary
- Adds an optional `caSecret` reference (`name` + `key`) to `strimziClusterRef` on both `KafkaBackup` and `KafkaRestore`, so users can point the operator at a CA secret that doesn't follow the Strimzi `{cluster}-cluster-ca-cert` / `ca.crt` naming convention.
- When `caSecret` is omitted the operator continues to use the default Strimzi layout (no behaviour change).
- Client CA auto-discovery is skipped when `caSecret` is provided, since an override implies a non-Strimzi secret layout.

## Context
Related to #7. The user in that issue hit trouble because they followed the `helm install oso-devops/kafka-backup-operator` snippet in our README, which actually installs a **different project** (`osodevops/kafka-backup-operator`, API group `kafka.oso.sh`). That install-command bug is addressed separately in #9. This PR addresses the real functional gap behind the report: the inability to use a non-conventional CA secret name/key with this operator.

## Changes
- `StrimziClusterRef.ca_secret: Option<SecretKeyRef>` added (`src/crd/common.rs`).
- `resolve_cluster_ca` now takes a `ca_override`; new `ca_secret_ref` helper centralises secret-name/key resolution (`src/strimzi/tls.rs`).
- `build_volumes_and_mounts` accepts a `ca_override` and uses `KeyToPath` to keep the in-pod mount path stable at `/certs/cluster-ca/ca.crt` regardless of the source key (`src/jobs/templates.rs`).
- Callers updated in `backup_job.rs`, `cronjob.rs`, `restore_job.rs`, `reconcilers/backup.rs`, `reconcilers/restore.rs`.
- CRDs regenerated and copied into the Helm chart.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (21 lib + 7 integration tests pass)
- [x] New unit tests: `tls::ca_secret_ref_*` and templates tests covering override vs default secret/key
- [x] CRDs regenerated via `cargo run --release --bin crdgen`; `caSecret` schema visible under `strimziClusterRef` with `name` and `key` required

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)