### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator


### PR DESCRIPTION
## Summary
Bumps `Cargo.toml` and the Helm `Chart.yaml` (version + appVersion) from `0.1.1` to `0.2.0` so we can cut a new tag. Release workflow is tag-triggered and validates that the Cargo.toml version matches the tag.

## Since v0.1.1
- feat: enable incremental backups via stable backup_id (#6)
- feat: support custom CA secret override on `strimziClusterRef` (#10)
- fix: align CRDs with kafka-backup core config (#4)
- chore(helm): rename chart `kafka-backup-operator` → `strimzi-backup-operator` (#11)
- docs: fix helm install command in README (#9)

Tag `v0.2.0` will be pushed after merge to trigger the Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)