### PR TITLE
fix: point image.repository at strimzi-backup-operator (v0.2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ spec:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Operator container image | `ghcr.io/osodevops/kafka-backup-operator` |
+| `image.repository` | Operator container image | `ghcr.io/osodevops/strimzi-backup-operator` |
 | `image.tag` | Image tag | Chart `appVersion` |
 | `image.pullPolicy` | Image pull policy | `Always` |
 | `replicaCount` | Number of operator replicas | `1` |
@@ -350,7 +350,7 @@ cargo clippy --all-features -- -D warnings
 cargo run --release --bin crdgen
 
 # Build Docker image
-docker build -t kafka-backup-operator .
+docker build -t strimzi-backup-operator .
 ```
 
 ### Local Development

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/values.yaml
+++ b/deploy/helm/strimzi-backup-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/osodevops/kafka-backup-operator
+  repository: ghcr.io/osodevops/strimzi-backup-operator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion
   tag: ""

--- a/docs/strimzi-backup-operator-prd.md
+++ b/docs/strimzi-backup-operator-prd.md
@@ -3,9 +3,9 @@
 
 **Project:** strimzi-backup-operator  
 **Author:** OSO DevOps  
-**Version:** 0.1.0  
-**Date:** February 2026  
-**Status:** Draft  
+**Document Version:** 0.2.1  
+**Date:** April 2026  
+**Status:** Implemented — see release notes for the current shipped version  
 **License:** Apache License 2.0 (aligned with Strimzi ecosystem)  
 **Repository:** github.com/osodevops/strimzi-backup-operator  
 **Website:** kafkabackup.com  


### PR DESCRIPTION
## Summary
Default `helm install` was pulling the **wrong operator**. The chart's default `image.repository` was `ghcr.io/osodevops/kafka-backup-operator` — the other project — but the release workflow has always pushed images to `ghcr.io/osodevops/strimzi-backup-operator` (via `IMAGE_NAME: \${{ github.repository }}`).

## Changes
- `values.yaml`: `image.repository` → `ghcr.io/osodevops/strimzi-backup-operator`
- `README.md`: helm values table + local `docker build` example
- `docs/strimzi-backup-operator-prd.md`: refresh stale header (Version/Date/Status)
- Bump `Cargo.toml` and `Chart.yaml` to `0.2.1` so we can cut a patch release

## Test plan
- [x] `cargo check`
- [x] `helm lint deploy/helm/strimzi-backup-operator`
- [ ] After merge: tag `v0.2.1`, watch release workflow push `ghcr.io/osodevops/strimzi-backup-operator:0.2.1` and chart-sync to helm-charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)