### PR TITLE
Fix backup job defaults and retention pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Fixed
+
+- Use the Helm-rendered operator service account for backup and restore job pods by default, with a `backupJobs.serviceAccountName` override for dedicated job service accounts. Fixes [#14](https://github.com/osodevops/strimzi-backup-operator/issues/14).
+- Update the default `kafka-backup` job image to the public `osodevops/kafka-backup:v0.15.3` release. Fixes [#15](https://github.com/osodevops/strimzi-backup-operator/issues/15).
+- Apply scheduled backup retention policies by discovering stored backup manifests, preserving `status.backupHistory`, and pruning expired backup objects from S3, Azure Blob Storage, GCS, or filesystem storage. Fixes [#16](https://github.com/osodevops/strimzi-backup-operator/issues/16).
+
+### Changed
+
+- Aligned the operator-generated backup and restore configuration with the current `kafka-backup` v0.15.3 storage layout and image behavior.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -235,6 +235,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -364,6 +370,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -563,8 +580,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -574,9 +593,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -590,6 +611,25 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -702,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +757,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -780,13 +827,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -819,6 +869,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +961,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -849,6 +1002,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -930,6 +1108,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "object_store",
  "prometheus",
  "regex",
  "schemars",
@@ -991,7 +1170,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
 ]
 
@@ -1079,6 +1258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1298,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1147,6 +1348,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.8.5",
+ "reqwest",
+ "ring",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1297,6 +1530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1588,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,8 +1674,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1378,7 +1695,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1388,6 +1715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1429,6 +1765,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1819,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1510,6 +1894,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1535,6 +1920,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1788,6 +2182,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +2211,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1836,6 +2257,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "tempfile"
@@ -1898,6 +2333,31 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2023,6 +2483,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2155,6 +2633,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2661,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2210,6 +2716,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2267,6 +2787,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2809,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2582,6 +3144,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,10 +3193,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 schemars = { version = "0.8", features = ["chrono"] }
+object_store = { version = "0.11", features = ["aws", "azure", "gcp", "http"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ spec:
 | `logging.level` | Rust log filter | `info,kafka_backup_operator=debug` |
 | `logging.format` | Log output format | `json` |
 | `serviceAccount.create` | Create a service account | `true` |
+| `backupJobs.serviceAccountName` | Service account used by backup/restore job pods (empty = operator service account) | `""` |
 | `azureWorkloadIdentity.enabled` | Enable Azure Workload Identity | `false` |
 | `azureWorkloadIdentity.clientId` | Azure Managed Identity client ID | `""` |
 | `metrics.enabled` | Enable Prometheus metrics | `true` |

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -247,7 +247,7 @@ spec:
                     type: array
                 type: object
               image:
-                description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -180,7 +180,7 @@ spec:
                     type: string
                 type: object
               image:
-                description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -247,7 +247,7 @@ spec:
                     type: array
                 type: object
               image:
-                description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -180,7 +180,7 @@ spec:
                     type: string
                 type: object
               image:
-                description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/deploy/helm/strimzi-backup-operator/templates/deployment.yaml
+++ b/deploy/helm/strimzi-backup-operator/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: BACKUP_JOB_SERVICE_ACCOUNT
+              value: {{ default (include "strimzi-backup-operator.serviceAccountName" .) .Values.backupJobs.serviceAccountName | quote }}
             {{- if .Values.watchNamespaces }}
             - name: STRIMZI_BACKUP_NAMESPACE
               value: {{ join "," .Values.watchNamespaces | quote }}

--- a/deploy/helm/strimzi-backup-operator/values.yaml
+++ b/deploy/helm/strimzi-backup-operator/values.yaml
@@ -24,6 +24,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+backupJobs:
+  # Service account used by backup and restore job pods.
+  # If empty, the chart passes the operator service account name.
+  serviceAccountName: ""
+
 # Azure Workload Identity configuration
 # When enabled, the operator can authenticate to Azure services using federated identity tokens
 # instead of storing credentials in Kubernetes secrets

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -77,7 +77,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -67,7 +67,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
 
+    #[error("Storage error: {0}")]
+    Storage(String),
+
     #[error("Backup '{name}' not found")]
     BackupNotFound { name: String },
 
@@ -53,6 +56,7 @@ impl Error {
             Error::SecretKeyMissing { .. } => "SecretKeyMissing",
             Error::KafkaUserNotFound { .. } => "KafkaUserNotFound",
             Error::InvalidConfig(_) => "InvalidConfiguration",
+            Error::Storage(_) => "StorageError",
             Error::BackupNotFound { .. } => "BackupNotFound",
             Error::JobCreationFailed(_) => "JobCreationFailed",
             Error::Finalizer(_) => "FinalizerError",

--- a/src/jobs/backup_job.rs
+++ b/src/jobs/backup_job.rs
@@ -21,6 +21,7 @@ pub fn build_backup_job(
     config_map_name: &str,
     cluster: &ResolvedKafkaCluster,
     auth: &ResolvedAuth,
+    service_account_name: Option<&str>,
 ) -> Result<Job> {
     let cr_name = backup.name_any();
     let namespace = backup.namespace().unwrap_or_default();
@@ -66,7 +67,7 @@ pub fn build_backup_job(
         containers: vec![container],
         volumes: Some(volumes),
         restart_policy: Some("Never".to_string()),
-        service_account_name: Some("kafka-backup-operator".to_string()),
+        service_account_name: service_account_name.map(str::to_string),
         ..Default::default()
     };
 
@@ -180,6 +181,7 @@ mod tests {
             "test-backup-config",
             &cluster,
             &ResolvedAuth::None,
+            Some("strimzi-backup-operator"),
         )
         .unwrap();
 

--- a/src/jobs/cronjob.rs
+++ b/src/jobs/cronjob.rs
@@ -20,6 +20,7 @@ pub fn build_backup_cronjob(
     config_map_name: &str,
     cluster: &ResolvedKafkaCluster,
     auth: &ResolvedAuth,
+    service_account_name: Option<&str>,
 ) -> Result<CronJob> {
     let cr_name = backup.name_any();
     let namespace = backup.namespace().unwrap_or_default();
@@ -68,7 +69,7 @@ pub fn build_backup_cronjob(
         containers: vec![container],
         volumes: Some(volumes),
         restart_policy: Some("Never".to_string()),
-        service_account_name: Some("kafka-backup-operator".to_string()),
+        service_account_name: service_account_name.map(str::to_string),
         ..Default::default()
     };
 

--- a/src/jobs/restore_job.rs
+++ b/src/jobs/restore_job.rs
@@ -22,6 +22,7 @@ pub fn build_restore_job(
     cluster: &ResolvedKafkaCluster,
     auth: &ResolvedAuth,
     source_backup: &KafkaBackup,
+    service_account_name: Option<&str>,
 ) -> Result<Job> {
     let cr_name = restore.name_any();
     let namespace = restore.namespace().unwrap_or_default();
@@ -70,7 +71,7 @@ pub fn build_restore_job(
         containers: vec![container],
         volumes: Some(volumes),
         restart_policy: Some("Never".to_string()),
-        service_account_name: Some("kafka-backup-operator".to_string()),
+        service_account_name: service_account_name.map(str::to_string),
         ..Default::default()
     };
 

--- a/src/reconcilers/backup.rs
+++ b/src/reconcilers/backup.rs
@@ -7,6 +7,7 @@ use kube::{
     api::{Api, Patch, PatchParams, PostParams, ResourceExt},
     Client,
 };
+use std::collections::BTreeSet;
 use tracing::{debug, error, info, warn};
 
 use crate::adapters::backup_config::build_backup_config_yaml;
@@ -16,7 +17,11 @@ use crate::error::{Error, Result};
 use crate::jobs::backup_job::build_backup_job;
 use crate::jobs::cronjob::build_backup_cronjob;
 use crate::metrics::prometheus::MetricsState;
-use crate::reconcilers::{FINALIZER, TRIGGER_ANNOTATION, TRIGGER_VALUE_NOW};
+use crate::reconcilers::{
+    job_service_account_name, FINALIZER, TRIGGER_ANNOTATION, TRIGGER_VALUE_NOW,
+};
+use crate::retention::policy::evaluate_retention;
+use crate::retention::storage::{discover_backup_history, prune_backup_ids};
 use crate::status::conditions::*;
 use crate::strimzi::kafka_cr::resolve_kafka_cluster;
 use crate::strimzi::kafka_user::resolve_auth;
@@ -89,11 +94,17 @@ pub async fn reconcile_backup(
         .await?;
 
     // Step 5: Check for scheduled vs one-shot
+    let job_service_account = job_service_account_name();
     if let Some(schedule) = &backup.spec.schedule {
         if !schedule.suspend {
             // Create CronJob
-            let cronjob =
-                build_backup_cronjob(&backup, &config_map_name, &kafka_cluster, &resolved_auth)?;
+            let cronjob = build_backup_cronjob(
+                &backup,
+                &config_map_name,
+                &kafka_cluster,
+                &resolved_auth,
+                job_service_account.as_deref(),
+            )?;
             let cronjob_api: Api<k8s_openapi::api::batch::v1::CronJob> =
                 Api::namespaced(client.clone(), &namespace);
             let cronjob_name = format!("{name}-scheduled");
@@ -125,6 +136,7 @@ pub async fn reconcile_backup(
             &config_map_name,
             &kafka_cluster,
             &resolved_auth,
+            job_service_account.as_deref(),
         )?;
 
         let jobs_api: Api<Job> = Api::namespaced(client.clone(), &namespace);
@@ -150,6 +162,7 @@ pub async fn reconcile_backup(
 
     // Step 8: Check running job status and update
     check_job_completion(&client, &backup_api, &backup, generation).await?;
+    apply_retention_policy(&client, &backup_api, &backup, generation).await?;
 
     Ok(())
 }
@@ -297,6 +310,85 @@ async fn is_job_running(jobs_api: &Api<Job>, backup_name: &str) -> Result<bool> 
     Ok(running)
 }
 
+async fn apply_retention_policy(
+    client: &Client,
+    backup_api: &Api<KafkaBackup>,
+    backup: &KafkaBackup,
+    generation: i64,
+) -> Result<()> {
+    let Some(retention) = &backup.spec.retention else {
+        return Ok(());
+    };
+    if backup.spec.schedule.is_none() || !retention.prune_on_schedule {
+        return Ok(());
+    }
+
+    let name = backup.name_any();
+    let namespace = backup.namespace().unwrap_or_default();
+    let mut history = current_backup_status(backup_api, &name)
+        .await?
+        .backup_history;
+
+    let discovered =
+        discover_backup_history(client, &namespace, &backup.spec.storage, &name).await?;
+    merge_backup_history(&mut history, discovered);
+
+    let active_backup_ids = active_backup_ids(client, &namespace, &name, backup).await?;
+    let mut to_prune = evaluate_retention(&history, retention);
+    to_prune.retain(|id| !active_backup_ids.contains(id));
+
+    if to_prune.is_empty() {
+        patch_backup_history(backup_api, &name, &history).await?;
+        return Ok(());
+    }
+
+    let pruned = prune_backup_ids(client, &namespace, &backup.spec.storage, &to_prune).await?;
+    history.retain(|entry| !pruned.contains(&entry.id));
+    patch_backup_history(backup_api, &name, &history).await?;
+
+    info!(
+        %name,
+        generation,
+        pruned = pruned.len(),
+        "Applied backup retention policy"
+    );
+
+    Ok(())
+}
+
+async fn active_backup_ids(
+    client: &Client,
+    namespace: &str,
+    backup_name: &str,
+    backup: &KafkaBackup,
+) -> Result<BTreeSet<String>> {
+    let jobs_api: Api<Job> = Api::namespaced(client.clone(), namespace);
+    let lp = kube::api::ListParams::default().labels(&format!(
+        "kafkabackup.com/backup={backup_name},kafkabackup.com/type=backup"
+    ));
+    let jobs = jobs_api.list(&lp).await?;
+    let mut active = BTreeSet::new();
+
+    for job in jobs {
+        let is_active = job
+            .status
+            .as_ref()
+            .is_some_and(|status| status.active.unwrap_or(0) > 0);
+        if !is_active {
+            continue;
+        }
+
+        if let Some(job_name) = job.metadata.name {
+            active.insert(job_name);
+        }
+        if backup.spec.offset_storage.is_some() {
+            active.insert(backup_name.to_string());
+        }
+    }
+
+    Ok(active)
+}
+
 async fn check_job_completion(
     client: &Client,
     backup_api: &Api<KafkaBackup>,
@@ -353,11 +445,9 @@ async fn check_job_completion(
 }
 
 async fn update_status_running(api: &Api<KafkaBackup>, name: &str, generation: i64) -> Result<()> {
-    let status = KafkaBackupStatus {
-        conditions: vec![not_ready(REASON_BACKUP_RUNNING, "Backup job is running")],
-        observed_generation: Some(generation),
-        ..Default::default()
-    };
+    let mut status = current_backup_status(api, name).await?;
+    status.conditions = vec![not_ready(REASON_BACKUP_RUNNING, "Backup job is running")];
+    status.observed_generation = Some(generation);
     patch_status(api, name, &status).await
 }
 
@@ -367,15 +457,13 @@ async fn update_status_scheduled(
     generation: i64,
     next_backup: &str,
 ) -> Result<()> {
-    let status = KafkaBackupStatus {
-        conditions: vec![ready(
-            REASON_BACKUP_SCHEDULED,
-            &format!("Next backup scheduled: {next_backup}"),
-        )],
-        observed_generation: Some(generation),
-        next_scheduled_backup: Some(next_backup.to_string()),
-        ..Default::default()
-    };
+    let mut status = current_backup_status(api, name).await?;
+    status.conditions = vec![ready(
+        REASON_BACKUP_SCHEDULED,
+        &format!("Next backup scheduled: {next_backup}"),
+    )];
+    status.observed_generation = Some(generation);
+    status.next_scheduled_backup = Some(next_backup.to_string());
     patch_status(api, name, &status).await
 }
 
@@ -385,6 +473,7 @@ async fn update_status_completed(
     generation: i64,
     entry: &BackupHistoryEntry,
 ) -> Result<()> {
+    let mut status = current_backup_status(api, name).await?;
     let last_backup = LastBackupInfo {
         id: entry.id.clone(),
         start_time: entry.start_time,
@@ -397,15 +486,13 @@ async fn update_status_completed(
         newest_timestamp: None,
     };
 
-    let status = KafkaBackupStatus {
-        conditions: vec![ready(
-            REASON_BACKUP_COMPLETED,
-            "Backup completed successfully",
-        )],
-        last_backup: Some(last_backup),
-        observed_generation: Some(generation),
-        ..Default::default()
-    };
+    status.conditions = vec![ready(
+        REASON_BACKUP_COMPLETED,
+        "Backup completed successfully",
+    )];
+    status.last_backup = Some(last_backup);
+    status.observed_generation = Some(generation);
+    upsert_history_entry(&mut status.backup_history, entry.clone());
     patch_status(api, name, &status).await
 }
 
@@ -415,12 +502,51 @@ async fn update_status_error(
     generation: i64,
     error: &Error,
 ) -> Result<()> {
-    let status = KafkaBackupStatus {
-        conditions: error_conditions(error.reason(), &error.to_string()),
-        observed_generation: Some(generation),
-        ..Default::default()
-    };
+    let mut status = current_backup_status(api, name).await?;
+    status.conditions = error_conditions(error.reason(), &error.to_string());
+    status.observed_generation = Some(generation);
     patch_status(api, name, &status).await
+}
+
+async fn current_backup_status(api: &Api<KafkaBackup>, name: &str) -> Result<KafkaBackupStatus> {
+    Ok(api.get_status(name).await?.status.unwrap_or_default())
+}
+
+fn merge_backup_history(
+    history: &mut Vec<BackupHistoryEntry>,
+    discovered: Vec<BackupHistoryEntry>,
+) {
+    for entry in discovered {
+        upsert_history_entry(history, entry);
+    }
+    history.sort_by_key(|entry| std::cmp::Reverse(entry.start_time));
+}
+
+fn upsert_history_entry(history: &mut Vec<BackupHistoryEntry>, mut entry: BackupHistoryEntry) {
+    if let Some(existing) = history.iter_mut().find(|existing| existing.id == entry.id) {
+        if entry.completion_time.is_none() {
+            entry.completion_time = existing.completion_time;
+        }
+        *existing = entry;
+    } else {
+        history.push(entry);
+    }
+    history.sort_by_key(|entry| std::cmp::Reverse(entry.start_time));
+}
+
+async fn patch_backup_history(
+    api: &Api<KafkaBackup>,
+    name: &str,
+    history: &[BackupHistoryEntry],
+) -> Result<()> {
+    let patch = serde_json::json!({ "status": { "backupHistory": history } });
+    api.patch_status(
+        name,
+        &PatchParams::apply("kafka-backup-operator"),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    Ok(())
 }
 
 async fn patch_status(

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -8,7 +8,27 @@ pub const FINALIZER: &str = "kafkabackup.com/cleanup";
 pub const TRIGGER_ANNOTATION: &str = "kafkabackup.com/trigger";
 pub const TRIGGER_VALUE_NOW: &str = "now";
 
-/// Default backup image. Pinned to a specific version so behaviour is deterministic —
-/// v0.13.5 is the first release that activates incremental one-shot backups from an
-/// `offset_storage` block alone (see kafka-backup PR #92).
-pub const DEFAULT_BACKUP_IMAGE: &str = "ghcr.io/osodevops/kafka-backup:v0.13.5";
+/// Default backup image. Pinned to a public, current kafka-backup release so
+/// backup/restore job behavior is deterministic and the image is anonymously
+/// pullable by Kubernetes.
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.3";
+
+/// Environment variable used by the Helm chart to pass the service account that
+/// backup/restore job pods should run as.
+pub const JOB_SERVICE_ACCOUNT_ENV: &str = "BACKUP_JOB_SERVICE_ACCOUNT";
+
+/// Fallback used outside Helm. The chart sets `BACKUP_JOB_SERVICE_ACCOUNT` to
+/// its rendered service account name, which handles custom release names and
+/// `serviceAccount.name` overrides.
+pub const DEFAULT_JOB_SERVICE_ACCOUNT: &str = "strimzi-backup-operator";
+
+pub fn job_service_account_name() -> Option<String> {
+    let value = std::env::var(JOB_SERVICE_ACCOUNT_ENV)
+        .unwrap_or_else(|_| DEFAULT_JOB_SERVICE_ACCOUNT.to_string());
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}

--- a/src/reconcilers/restore.rs
+++ b/src/reconcilers/restore.rs
@@ -15,7 +15,7 @@ use crate::crd::{KafkaBackup, KafkaRestore, KafkaRestoreStatus};
 use crate::error::{Error, Result};
 use crate::jobs::restore_job::build_restore_job;
 use crate::metrics::prometheus::MetricsState;
-use crate::reconcilers::FINALIZER;
+use crate::reconcilers::{job_service_account_name, FINALIZER};
 use crate::status::conditions::*;
 use crate::strimzi::kafka_cr::resolve_kafka_cluster;
 use crate::strimzi::kafka_user::resolve_auth;
@@ -118,6 +118,7 @@ pub async fn reconcile_restore(
     let jobs_api: Api<Job> = Api::namespaced(client.clone(), &namespace);
     if !is_job_running(&jobs_api, &name).await? {
         let job_name = format!("{name}-{}", Utc::now().format("%Y%m%d-%H%M%S"));
+        let job_service_account = job_service_account_name();
         let job = build_restore_job(
             &restore,
             &job_name,
@@ -125,6 +126,7 @@ pub async fn reconcile_restore(
             &kafka_cluster,
             &resolved_auth,
             &source_backup,
+            job_service_account.as_deref(),
         )?;
 
         jobs_api

--- a/src/retention/mod.rs
+++ b/src/retention/mod.rs
@@ -1,1 +1,2 @@
 pub mod policy;
+pub mod storage;

--- a/src/retention/storage.rs
+++ b/src/retention/storage.rs
@@ -1,0 +1,541 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use object_store::aws::AmazonS3Builder;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::adapters::secrets::{extract_secret_data, get_secret};
+use crate::crd::common::{BackupHistoryEntry, BackupStatus, StorageSpec, StorageType};
+use crate::error::{Error, Result};
+
+struct BackupObjectStore {
+    store: Arc<dyn ObjectStore>,
+    prefix: Option<String>,
+}
+
+impl BackupObjectStore {
+    fn new(store: Arc<dyn ObjectStore>, prefix: Option<String>) -> Self {
+        Self {
+            store,
+            prefix: normalize_optional_prefix(prefix),
+        }
+    }
+
+    fn full_path(&self, key: &str) -> Path {
+        Path::from(join_key(self.prefix.as_deref(), key))
+    }
+
+    fn strip_prefix(&self, key: &str) -> String {
+        match self.prefix.as_deref() {
+            Some(prefix) => key
+                .strip_prefix(&format!("{prefix}/"))
+                .unwrap_or(key)
+                .to_string(),
+            None => key.to_string(),
+        }
+    }
+
+    async fn get(&self, key: &str) -> Result<Vec<u8>> {
+        let path = self.full_path(key);
+        let response = self.store.get(&path).await.map_err(storage_error)?;
+        let bytes = response.bytes().await.map_err(storage_error)?;
+        Ok(bytes.to_vec())
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        let path = self.full_path(prefix);
+        let mut stream = self.store.list(Some(&path));
+        let mut keys = Vec::new();
+
+        while let Some(item) = stream.next().await {
+            let metadata = item.map_err(storage_error)?;
+            keys.push(self.strip_prefix(metadata.location.as_ref()));
+        }
+
+        keys.sort();
+        Ok(keys)
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let path = self.full_path(key);
+        match self.store.delete(&path).await {
+            Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
+            Err(e) => Err(storage_error(e)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredBackupManifest {
+    backup_id: String,
+    created_at: i64,
+    #[serde(default)]
+    topics: Vec<StoredTopic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredTopic {
+    #[serde(default)]
+    partitions: Vec<StoredPartition>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredPartition {
+    #[serde(default)]
+    segments: Vec<StoredSegment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredSegment {
+    #[serde(default)]
+    compressed_size: u64,
+}
+
+pub async fn discover_backup_history(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+    owner_name: &str,
+) -> Result<Vec<BackupHistoryEntry>> {
+    let store = build_store(client, namespace, storage).await?;
+    let keys = store.list("").await?;
+    let mut history = Vec::new();
+
+    for key in keys.iter().filter(|k| k.ends_with("/manifest.json")) {
+        let backup_id = key.trim_end_matches("/manifest.json");
+        if !backup_id_belongs_to_cr(backup_id, owner_name) {
+            continue;
+        }
+
+        let bytes = match store.get(key).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                warn!(%key, error = %e, "Failed to read backup manifest during retention discovery");
+                continue;
+            }
+        };
+
+        let manifest: StoredBackupManifest = match serde_json::from_slice(&bytes) {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                warn!(%key, error = %e, "Failed to parse backup manifest during retention discovery");
+                continue;
+            }
+        };
+
+        history.push(manifest_to_history_entry(manifest));
+    }
+
+    Ok(history)
+}
+
+pub async fn prune_backup_ids(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+    backup_ids: &[String],
+) -> Result<Vec<String>> {
+    if backup_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let store = build_store(client, namespace, storage).await?;
+    let mut pruned = Vec::new();
+
+    for backup_id in backup_ids {
+        let prefix = format!("{}/", backup_id.trim_end_matches('/'));
+        let keys = store.list(&prefix).await?;
+
+        if keys.is_empty() {
+            debug!(%backup_id, "No storage objects found for retained backup id");
+            pruned.push(backup_id.clone());
+            continue;
+        }
+
+        for key in keys.iter().filter(|key| key.starts_with(&prefix)) {
+            store.delete(key).await?;
+        }
+
+        info!(
+            %backup_id,
+            deleted_objects = keys.len(),
+            "Pruned expired backup from storage"
+        );
+        pruned.push(backup_id.clone());
+    }
+
+    Ok(pruned)
+}
+
+pub fn backup_id_belongs_to_cr(backup_id: &str, owner_name: &str) -> bool {
+    backup_id == owner_name || backup_id.starts_with(&format!("{owner_name}-"))
+}
+
+async fn build_store(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+) -> Result<BackupObjectStore> {
+    match storage.storage_type {
+        StorageType::S3 => build_s3_store(client, namespace, storage).await,
+        StorageType::Azure => build_azure_store(client, namespace, storage).await,
+        StorageType::Gcs => build_gcs_store(client, namespace, storage).await,
+        StorageType::Filesystem => build_filesystem_store(storage),
+    }
+}
+
+async fn build_s3_store(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+) -> Result<BackupObjectStore> {
+    let s3 = storage.s3.as_ref().ok_or_else(|| {
+        Error::InvalidConfig("Storage type is S3 but s3 config is missing".to_string())
+    })?;
+
+    let mut builder = AmazonS3Builder::from_env().with_bucket_name(&s3.bucket);
+
+    if let Some(region) = &s3.region {
+        builder = builder.with_region(region);
+    }
+    if let Some(endpoint) = &s3.endpoint {
+        builder = builder.with_endpoint(endpoint);
+        builder = builder.with_virtual_hosted_style_request(false);
+    }
+    if s3.force_path_style.unwrap_or(false) {
+        builder = builder.with_virtual_hosted_style_request(false);
+    }
+    if s3.allow_http.unwrap_or(false) {
+        builder = builder.with_allow_http(true);
+    }
+
+    let mut access_key = None;
+    let mut secret_key = None;
+    let mut token = None;
+
+    if let Some(secret_ref) = &s3.credentials_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        let credentials = extract_secret_data(&secret, &secret_ref.key)?;
+        let parsed = parse_aws_shared_credentials(&credentials);
+        access_key = parsed.access_key_id;
+        secret_key = parsed.secret_access_key;
+        token = parsed.session_token;
+    }
+
+    if let Some(secret_ref) = &s3.access_key_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        access_key = Some(extract_secret_data(&secret, &secret_ref.key)?);
+    }
+    if let Some(secret_ref) = &s3.secret_key_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        secret_key = Some(extract_secret_data(&secret, &secret_ref.key)?);
+    }
+
+    if let Some(access_key) = access_key {
+        builder = builder.with_access_key_id(access_key);
+    }
+    if let Some(secret_key) = secret_key {
+        builder = builder.with_secret_access_key(secret_key);
+    }
+    if let Some(token) = token {
+        builder = builder.with_token(token);
+    }
+
+    let store = builder.build().map_err(storage_error)?;
+    Ok(BackupObjectStore::new(Arc::new(store), s3.prefix.clone()))
+}
+
+async fn build_azure_store(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+) -> Result<BackupObjectStore> {
+    let azure = storage.azure.as_ref().ok_or_else(|| {
+        Error::InvalidConfig("Storage type is Azure but azure config is missing".to_string())
+    })?;
+
+    let mut builder = MicrosoftAzureBuilder::new()
+        .with_account(&azure.storage_account)
+        .with_container_name(&azure.container);
+
+    if let Some(endpoint) = &azure.endpoint {
+        builder = builder.with_endpoint(endpoint.clone());
+        if endpoint.starts_with("http://") {
+            builder = builder.with_allow_http(true);
+        }
+    }
+
+    let account_key_ref = azure
+        .account_key_secret
+        .as_ref()
+        .or(azure.credentials_secret.as_ref());
+    if let Some(secret_ref) = account_key_ref {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        builder = builder.with_access_key(extract_secret_data(&secret, &secret_ref.key)?);
+    }
+
+    if let Some(secret_ref) = &azure.sas_token_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        let sas_token = extract_secret_data(&secret, &secret_ref.key)?;
+        let pairs = sas_token_pairs(&sas_token);
+        builder = builder.with_sas_authorization(pairs);
+    }
+
+    if let Some(client_id) = &azure.client_id {
+        builder = builder.with_client_id(client_id);
+    }
+    if let Some(tenant_id) = &azure.tenant_id {
+        builder = builder.with_tenant_id(tenant_id);
+    }
+    if let Some(secret_ref) = &azure.client_secret_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        builder = builder.with_client_secret(extract_secret_data(&secret, &secret_ref.key)?);
+    }
+    if azure.use_workload_identity.unwrap_or(false) {
+        if let Ok(token_file) = std::env::var("AZURE_FEDERATED_TOKEN_FILE") {
+            builder = builder.with_federated_token_file(token_file);
+        }
+        builder = builder.with_use_azure_cli(false);
+    }
+
+    let store = builder.build().map_err(storage_error)?;
+    Ok(BackupObjectStore::new(
+        Arc::new(store),
+        azure.prefix.clone(),
+    ))
+}
+
+async fn build_gcs_store(
+    client: &kube::Client,
+    namespace: &str,
+    storage: &StorageSpec,
+) -> Result<BackupObjectStore> {
+    let gcs = storage.gcs.as_ref().ok_or_else(|| {
+        Error::InvalidConfig("Storage type is GCS but gcs config is missing".to_string())
+    })?;
+
+    let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(&gcs.bucket);
+
+    if let Some(secret_ref) = &gcs.credentials_secret {
+        let secret = get_secret(client, &secret_ref.name, namespace).await?;
+        builder = builder.with_service_account_key(extract_secret_data(&secret, &secret_ref.key)?);
+    } else if let Some(path) = &gcs.service_account_path {
+        builder = builder.with_service_account_path(path);
+    }
+
+    let store = builder.build().map_err(storage_error)?;
+    Ok(BackupObjectStore::new(Arc::new(store), gcs.prefix.clone()))
+}
+
+fn build_filesystem_store(storage: &StorageSpec) -> Result<BackupObjectStore> {
+    let filesystem = storage.filesystem.as_ref().ok_or_else(|| {
+        Error::InvalidConfig(
+            "Storage type is Filesystem but filesystem config is missing".to_string(),
+        )
+    })?;
+    let store = LocalFileSystem::new_with_prefix(&filesystem.path).map_err(storage_error)?;
+    Ok(BackupObjectStore::new(Arc::new(store), None))
+}
+
+fn manifest_to_history_entry(manifest: StoredBackupManifest) -> BackupHistoryEntry {
+    let start_time =
+        DateTime::<Utc>::from_timestamp_millis(manifest.created_at).unwrap_or_else(Utc::now);
+    let topics_backed_up = i32::try_from(manifest.topics.len()).ok();
+    let partitions_backed_up = manifest
+        .topics
+        .iter()
+        .map(|topic| topic.partitions.len())
+        .sum::<usize>();
+    let size_bytes = manifest
+        .topics
+        .iter()
+        .flat_map(|topic| &topic.partitions)
+        .flat_map(|partition| &partition.segments)
+        .map(|segment| segment.compressed_size)
+        .sum::<u64>();
+
+    BackupHistoryEntry {
+        id: manifest.backup_id,
+        status: BackupStatus::Completed,
+        start_time,
+        completion_time: None,
+        size_bytes: i64::try_from(size_bytes).ok(),
+        topics_backed_up,
+        partitions_backed_up: i32::try_from(partitions_backed_up).ok(),
+    }
+}
+
+#[derive(Default)]
+struct AwsSharedCredentials {
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+    session_token: Option<String>,
+}
+
+fn parse_aws_shared_credentials(input: &str) -> AwsSharedCredentials {
+    let mut credentials = AwsSharedCredentials::default();
+
+    for line in input.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = trim_credential_value(value);
+
+        match key {
+            "aws_access_key_id" | "access_key" | "access_key_id" => {
+                credentials.access_key_id = Some(value);
+            }
+            "aws_secret_access_key" | "secret_key" | "secret_access_key" => {
+                credentials.secret_access_key = Some(value);
+            }
+            "aws_session_token" | "session_token" | "token" => {
+                credentials.session_token = Some(value);
+            }
+            _ => {}
+        }
+    }
+
+    credentials
+}
+
+fn trim_credential_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}
+
+fn sas_token_pairs(token: &str) -> Vec<(String, String)> {
+    token
+        .trim_start_matches('?')
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+fn normalize_optional_prefix(prefix: Option<String>) -> Option<String> {
+    prefix
+        .map(|prefix| prefix.trim_matches('/').to_string())
+        .filter(|prefix| !prefix.is_empty())
+}
+
+fn join_key(prefix: Option<&str>, key: &str) -> String {
+    let key = key.trim_start_matches('/');
+    match (prefix, key.is_empty()) {
+        (Some(prefix), false) => format!("{prefix}/{key}"),
+        (Some(prefix), true) => prefix.to_string(),
+        (None, _) => key.to_string(),
+    }
+}
+
+fn storage_error(error: object_store::Error) -> Error {
+    Error::Storage(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn backup_id_filter_matches_operator_owned_names() {
+        assert!(backup_id_belongs_to_cr("daily-backup", "daily-backup"));
+        assert!(backup_id_belongs_to_cr(
+            "daily-backup-scheduled-28819192",
+            "daily-backup"
+        ));
+        assert!(backup_id_belongs_to_cr(
+            "daily-backup-20260428-010203",
+            "daily-backup"
+        ));
+        assert!(!backup_id_belongs_to_cr("daily-backup2-1", "daily-backup"));
+    }
+
+    #[test]
+    fn aws_shared_credentials_are_parsed() {
+        let credentials = parse_aws_shared_credentials(
+            r#"
+            [default]
+            aws_access_key_id = "access"
+            aws_secret_access_key = 'secret'
+            aws_session_token = token
+            "#,
+        );
+
+        assert_eq!(credentials.access_key_id.as_deref(), Some("access"));
+        assert_eq!(credentials.secret_access_key.as_deref(), Some("secret"));
+        assert_eq!(credentials.session_token.as_deref(), Some("token"));
+    }
+
+    #[test]
+    fn manifest_entry_uses_core_layout_metadata() {
+        let manifest = StoredBackupManifest {
+            backup_id: "daily-backup-1".to_string(),
+            created_at: 1_777_334_400_000,
+            topics: vec![StoredTopic {
+                partitions: vec![StoredPartition {
+                    segments: vec![
+                        StoredSegment {
+                            compressed_size: 100,
+                        },
+                        StoredSegment {
+                            compressed_size: 200,
+                        },
+                    ],
+                }],
+            }],
+        };
+
+        let entry = manifest_to_history_entry(manifest);
+        assert_eq!(entry.id, "daily-backup-1");
+        assert_eq!(
+            entry.start_time,
+            Utc.with_ymd_and_hms(2026, 4, 28, 0, 0, 0).unwrap()
+        );
+        assert_eq!(entry.size_bytes, Some(300));
+        assert_eq!(entry.topics_backed_up, Some(1));
+        assert_eq!(entry.partitions_backed_up, Some(1));
+    }
+
+    #[tokio::test]
+    async fn local_store_lists_and_deletes_backup_prefix() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let backup_dir = temp_dir.path().join("daily-backup-1");
+        std::fs::create_dir_all(backup_dir.join("topics/orders/partition=0")).unwrap();
+        std::fs::write(backup_dir.join("manifest.json"), "{}").unwrap();
+        std::fs::write(
+            backup_dir.join("topics/orders/partition=0/segment-000.bin.zst"),
+            b"segment",
+        )
+        .unwrap();
+
+        let store = BackupObjectStore::new(
+            Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap()),
+            None,
+        );
+
+        let keys = store.list("daily-backup-1/").await.unwrap();
+        assert_eq!(keys.len(), 2);
+
+        for key in keys {
+            store.delete(&key).await.unwrap();
+        }
+
+        assert!(store.list("daily-backup-1/").await.unwrap().is_empty());
+    }
+}

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -3,6 +3,7 @@ use kafka_backup_operator::crd::common::*;
 use kafka_backup_operator::crd::kafka_backup::*;
 use kafka_backup_operator::crd::KafkaBackup;
 use kafka_backup_operator::jobs::backup_job::build_backup_job;
+use kafka_backup_operator::jobs::cronjob::build_backup_cronjob;
 use kafka_backup_operator::strimzi::kafka_cr::ResolvedKafkaCluster;
 use kafka_backup_operator::strimzi::kafka_user::ResolvedAuth;
 
@@ -122,6 +123,7 @@ fn test_backup_job_creation() {
         "daily-backup-config",
         &cluster,
         &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
     )
     .unwrap();
 
@@ -149,6 +151,10 @@ fn test_backup_job_creation() {
 
     let spec = job.spec.as_ref().unwrap();
     let pod_spec = spec.template.spec.as_ref().unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("strimzi-backup-operator")
+    );
     assert_eq!(pod_spec.containers.len(), 1);
     assert_eq!(pod_spec.containers[0].name, "backup");
     assert!(pod_spec.containers[0]
@@ -162,6 +168,38 @@ fn test_backup_job_creation() {
         .unwrap()
         .iter()
         .any(|env| env.name == "BACKUP_ID"));
+}
+
+#[test]
+fn test_backup_cronjob_uses_configured_service_account() {
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let cronjob = build_backup_cronjob(
+        &backup,
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+
+    let pod_spec = cronjob
+        .spec
+        .as_ref()
+        .unwrap()
+        .job_template
+        .spec
+        .as_ref()
+        .unwrap()
+        .template
+        .spec
+        .as_ref()
+        .unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("strimzi-backup-operator")
+    );
 }
 
 #[test]
@@ -187,7 +225,15 @@ fn test_backup_with_tls_auth() {
     assert!(yaml.contains("ssl_certificate_location: /certs/user/user.crt"));
     assert!(yaml.contains("ssl_key_location: /certs/user/user.key"));
 
-    let job = build_backup_job(&backup, "test-job", "test-config", &cluster, &auth).unwrap();
+    let job = build_backup_job(
+        &backup,
+        "test-job",
+        "test-config",
+        &cluster,
+        &auth,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
 
     let volumes = job
         .spec

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -166,6 +166,7 @@ fn test_restore_job_creation() {
         &cluster,
         &ResolvedAuth::None,
         &backup,
+        Some("strimzi-backup-operator"),
     )
     .unwrap();
 
@@ -191,6 +192,10 @@ fn test_restore_job_creation() {
     assert_eq!(owner_refs[0].name, "pitr-restore");
 
     let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("strimzi-backup-operator")
+    );
     assert_eq!(pod_spec.containers[0].name, "restore");
     assert!(pod_spec.containers[0]
         .args


### PR DESCRIPTION
## Summary
- use the Helm-rendered operator service account for backup and restore job pods, with a backupJobs.serviceAccountName override
- update the default kafka-backup job image to public osodevops/kafka-backup:v0.15.3
- apply scheduled retention by discovering stored backup manifests and pruning expired objects across supported storage backends
- preserve backupHistory through status updates and document the changes in CHANGELOG.md

## kafka-backup alignment
- verified latest core release is v0.15.3 and pulled osodevops/kafka-backup:v0.15.3
- verified the image reports kafka-backup 0.15.3
- checked the local ~/development/kafka-backup repo through origin/main v0.15.3; operator storage/config coverage is aligned for the released image
- confirmed core still does not expose a prune/delete-backup command, so retention pruning remains operator-side

## Tests
- cargo check
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- helm lint deploy/helm/strimzi-backup-operator
- helm template service account default and override checks
- docker run --rm --platform linux/amd64 osodevops/kafka-backup:v0.15.3 --version
- git diff --check

Fixes #14
Fixes #15
Fixes #16