### PR TITLE
fix: support KafkaBackup logging configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 # Environment
 .env
 .env.local
+AGENTS.md
 
 # Build artifacts
 *.o

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.4 - 2026-05-08
+
+### Added
+
+- Add first-class `spec.logging` and `spec.env` support for `KafkaBackup` and `KafkaRestore` job pods. Fixes [#18](https://github.com/osodevops/strimzi-backup-operator/issues/18).
+
+### Changed
+
+- Update the default `kafka-backup` job image to `osodevops/kafka-backup:v0.15.5`.
+
 ## 0.2.2 - 2026-04-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.2"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ spec:
   backup:
     compression: zstd
     parallelism: 4
+  logging:
+    level: warn
+    format: json
+    modules:
+      kafka_backup: warn
+      rdkafka: info
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=warn,rdkafka=info"
   schedule:
     cron: "0 2 * * *"    # Daily at 2 AM
     timezone: "Europe/London"
@@ -141,6 +150,9 @@ spec:
     name: my-cluster-backup
   pointInTime:
     timestamp: "2026-02-12T14:30:00.000Z"
+  logging:
+    level: info
+    format: json
   topicMapping:
     - sourceTopic: orders
       targetTopic: orders-restored
@@ -281,6 +293,53 @@ spec:
 | `resources.requests.memory` | Memory request | `128Mi` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
+
+## Logging
+
+The operator deployment and the backup/restore job pods are configured separately.
+
+Configure the operator deployment log level with Helm:
+
+```yaml
+logging:
+  level: "info,kafka_backup_operator=debug"
+  format: json
+```
+
+Configure `kafka-backup` job logging on each `KafkaBackup` or `KafkaRestore`:
+
+```yaml
+apiVersion: kafkabackup.com/v1alpha1
+kind: KafkaBackup
+metadata:
+  name: debug-backup
+  namespace: kafka
+spec:
+  strimziClusterRef:
+    name: my-kafka-cluster
+  storage:
+    type: s3
+    s3:
+      bucket: my-kafka-backups
+      region: eu-west-1
+  logging:
+    level: warn
+    format: json
+    output: stderr
+    modules:
+      kafka_backup: warn
+      rdkafka: info
+```
+
+For environment-based logging, use top-level `spec.env`; these entries are added
+to backup and restore job containers:
+
+```yaml
+spec:
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=warn,rdkafka=info"
+```
 
 ## Monitoring
 

--- a/config/examples/kafka-backup-s3.yaml
+++ b/config/examples/kafka-backup-s3.yaml
@@ -41,6 +41,17 @@ spec:
     parallelism: 4
     stopAtCurrentOffsets: true
 
+  logging:
+    level: warn
+    format: json
+    modules:
+      kafka_backup: warn
+      rdkafka: info
+
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=warn,rdkafka=info"
+
   schedule:
     cron: "0 2 * * *"
     timezone: "UTC"

--- a/config/examples/kafka-restore-pitr.yaml
+++ b/config/examples/kafka-restore-pitr.yaml
@@ -21,6 +21,14 @@ spec:
   pointInTime:
     timestamp: "2026-02-13T01:30:00.000Z"
 
+  logging:
+    level: info
+    format: json
+
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=info,rdkafka=warn"
+
   topicMapping:
     - sourceTopic: "orders"
       targetTopic: "orders-restored"

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -246,10 +246,55 @@ spec:
                       type: string
                     type: array
                 type: object
+              env:
+                description: Additional environment variables for backup job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for backup job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for backup job pods
                 nullable: true

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -179,10 +179,55 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              env:
+                description: Additional environment variables for restore job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for restore job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for restore job pods
                 nullable: true

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.3
-appVersion: "0.2.2"
+version: 0.2.4
+appVersion: "0.2.4"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -246,10 +246,55 @@ spec:
                       type: string
                     type: array
                 type: object
+              env:
+                description: Additional environment variables for backup job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for backup job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for backup job pods
                 nullable: true

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -179,10 +179,55 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              env:
+                description: Additional environment variables for restore job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for restore job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for restore job pods
                 nullable: true

--- a/docs/strimzi-backup-operator-prd.md
+++ b/docs/strimzi-backup-operator-prd.md
@@ -172,6 +172,19 @@ spec:
     segmentSize: 268435456      # 256MB — max segment file size before rotation
     parallelism: 4              # Number of concurrent partition backup threads
 
+  # Logging for the backup job
+  logging:
+    level: warn                 # error | warn | info | debug | trace
+    format: json                # json | text
+    modules:
+      kafka_backup: warn
+      rdkafka: info
+
+  # Additional backup job environment variables
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=warn,rdkafka=info"
+
   # Schedule (cron format, optional — if omitted, runs once)
   schedule:
     cron: "0 2 * * *"           # Daily at 2:00 AM
@@ -296,6 +309,16 @@ spec:
     topicCreation: auto          # auto | manual — auto creates topics if missing
     existingTopicPolicy: fail    # fail | append | overwrite
     parallelism: 4
+
+  # Logging for the restore job
+  logging:
+    level: info
+    format: json
+
+  # Additional restore job environment variables
+  env:
+    - name: RUST_LOG
+      value: "kafka_backup=info,rdkafka=warn"
 
   # Resource requirements for the restore pod
   resources:

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -6,6 +6,7 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 use crate::strimzi::tls::ResolvedTlsCerts;
 
+use super::logging_config::build_logging_config;
 use super::storage_config::build_storage_config;
 
 /// Build the complete kafka-backup config YAML from a KafkaBackup CR and resolved resources
@@ -55,6 +56,16 @@ pub fn build_backup_config_yaml(
     // Storage
     let storage = build_storage_config(&backup.spec.storage)?;
     config.insert(Value::String("storage".to_string()), storage);
+
+    // Logging options
+    if let Some(logging) = &backup.spec.logging {
+        let logging = build_logging_config(logging);
+        if let Value::Mapping(ref m) = logging {
+            if !m.is_empty() {
+                config.insert(Value::String("logging".to_string()), logging);
+            }
+        }
+    }
 
     // Backup options
     if let Some(backup_opts) = &backup.spec.backup {
@@ -451,6 +462,8 @@ mod tests {
                 exclude: vec!["__.*".to_string()],
             }),
             connection: None,
+            logging: None,
+            env: Vec::new(),
             storage: StorageSpec {
                 storage_type: StorageType::S3,
                 s3: Some(S3StorageSpec {
@@ -520,6 +533,30 @@ mod tests {
         assert!(yaml.contains("mode: backup"));
         assert!(yaml.contains("bootstrap_servers:"));
         assert!(yaml.contains("orders.*"));
+    }
+
+    #[test]
+    fn test_build_backup_config_includes_logging() {
+        let mut backup = test_backup();
+        backup.spec.logging = Some(LoggingSpec {
+            level: Some("warn".to_string()),
+            format: Some("json".to_string()),
+            output: Some("stderr".to_string()),
+            modules: std::collections::BTreeMap::from([
+                ("kafka_backup".to_string(), "debug".to_string()),
+                ("rdkafka".to_string(), "info".to_string()),
+            ]),
+            rotation: None,
+        });
+
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("logging:"));
+        assert!(yaml.contains("level: warn"));
+        assert!(yaml.contains("format: json"));
+        assert!(yaml.contains("output: stderr"));
+        assert!(yaml.contains("kafka_backup: debug"));
+        assert!(yaml.contains("rdkafka: info"));
     }
 
     #[test]

--- a/src/adapters/logging_config.rs
+++ b/src/adapters/logging_config.rs
@@ -1,0 +1,64 @@
+use serde_yaml::Value;
+
+use crate::crd::common::LoggingSpec;
+
+/// Build the kafka-backup logging config section.
+pub fn build_logging_config(logging: &LoggingSpec) -> Value {
+    let mut config = serde_yaml::Mapping::new();
+
+    if let Some(level) = &logging.level {
+        config.insert(
+            Value::String("level".to_string()),
+            Value::String(level.clone()),
+        );
+    }
+    if let Some(format) = &logging.format {
+        config.insert(
+            Value::String("format".to_string()),
+            Value::String(format.clone()),
+        );
+    }
+    if let Some(output) = &logging.output {
+        config.insert(
+            Value::String("output".to_string()),
+            Value::String(output.clone()),
+        );
+    }
+    if !logging.modules.is_empty() {
+        config.insert(
+            Value::String("modules".to_string()),
+            Value::Mapping(
+                logging
+                    .modules
+                    .iter()
+                    .map(|(module, level)| {
+                        (Value::String(module.clone()), Value::String(level.clone()))
+                    })
+                    .collect(),
+            ),
+        );
+    }
+    if let Some(rotation) = &logging.rotation {
+        let mut rotation_config = serde_yaml::Mapping::new();
+        if let Some(max_size_mb) = rotation.max_size_mb {
+            rotation_config.insert(
+                Value::String("max_size_mb".to_string()),
+                Value::Number(serde_yaml::Number::from(max_size_mb)),
+            );
+        }
+        if let Some(max_files) = rotation.max_files {
+            rotation_config.insert(
+                Value::String("max_files".to_string()),
+                Value::Number(serde_yaml::Number::from(max_files)),
+            );
+        }
+        if !rotation_config.is_empty() {
+            config.insert(
+                Value::String("rotation".to_string()),
+                Value::Mapping(rotation_config),
+            );
+        }
+    }
+
+    Value::Mapping(config)
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup_config;
+pub mod logging_config;
 pub mod restore_config;
 pub mod secrets;
 pub mod storage_config;

--- a/src/adapters/restore_config.rs
+++ b/src/adapters/restore_config.rs
@@ -6,6 +6,7 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 use crate::strimzi::tls::ResolvedTlsCerts;
 
+use super::logging_config::build_logging_config;
 use super::storage_config::build_storage_config;
 
 /// Build the complete kafka-backup config YAML for a restore operation
@@ -37,6 +38,16 @@ pub fn build_restore_config_yaml(
     // Storage (from source backup CR)
     let storage = build_storage_config(&source_backup.spec.storage)?;
     config.insert(Value::String("storage".to_string()), storage);
+
+    // Logging options
+    if let Some(logging) = &restore.spec.logging {
+        let logging = build_logging_config(logging);
+        if let Value::Mapping(ref m) = logging {
+            if !m.is_empty() {
+                config.insert(Value::String("logging".to_string()), logging);
+            }
+        }
+    }
 
     // Restore options
     let restore_opts = build_restore_options(restore)?;

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -166,6 +166,39 @@ pub struct KafkaConnectionSpec {
     pub connections_per_broker: Option<usize>,
 }
 
+/// Logging configuration passed through to kafka-backup job config.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LoggingSpec {
+    /// Default log level: error, warn, info, debug, or trace
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<String>,
+    /// Log format: text or json
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    /// Log output: stderr, stdout, or a file path supported by kafka-backup
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    /// Module-specific log levels
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub modules: BTreeMap<String, String>,
+    /// File log rotation settings
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation: Option<LoggingRotationSpec>,
+}
+
+/// File log rotation settings for kafka-backup logging.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LoggingRotationSpec {
+    /// Maximum size of a log file before rotation, in MiB
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_size_mb: Option<u64>,
+    /// Maximum number of rotated log files to keep
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_files: Option<u32>,
+}
+
 /// Metrics HTTP server configuration for kafka-backup job pods.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -397,7 +430,7 @@ pub struct ContainerOverrides {
 }
 
 /// Schema helper: a nullable free-form object (type: object with no properties)
-fn free_form_object(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+pub(crate) fn free_form_object(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
     schemars::schema::Schema::Object(schemars::schema::SchemaObject {
         instance_type: Some(schemars::schema::InstanceType::Object.into()),
         extensions: {
@@ -413,7 +446,9 @@ fn free_form_object(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema:
 }
 
 /// Schema helper: an array of free-form objects
-fn free_form_object_array(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+pub(crate) fn free_form_object_array(
+    _: &mut schemars::gen::SchemaGenerator,
+) -> schemars::schema::Schema {
     schemars::schema::Schema::Object(schemars::schema::SchemaObject {
         instance_type: Some(schemars::schema::InstanceType::Array.into()),
         array: Some(Box::new(schemars::schema::ArrayValidation {

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{
     AuthenticationSpec, BackupHistoryEntry, Condition, ConsumerGroupSelection, KafkaConnectionSpec,
-    LastBackupInfo, MetricsSpec, OffsetStorageSpec, PodTemplateSpec, ResourceRequirementsSpec,
-    SecretKeyRef, StorageSpec, StrimziClusterRef, TopicSelection,
+    LastBackupInfo, LoggingSpec, MetricsSpec, OffsetStorageSpec, PodTemplateSpec,
+    ResourceRequirementsSpec, SecretKeyRef, StorageSpec, StrimziClusterRef, TopicSelection,
 };
 
 /// KafkaBackup defines a backup configuration for a Strimzi-managed Kafka cluster.
@@ -46,6 +46,15 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consumer_groups: Option<ConsumerGroupSelection>,
 
+    /// Logging configuration for backup job pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logging: Option<LoggingSpec>,
+
+    /// Additional environment variables for backup job pods
+    #[schemars(schema_with = "super::common::free_form_object_array")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<serde_json::Value>,
+
     /// Storage destination configuration
     pub storage: StorageSpec,
 
@@ -77,7 +86,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::common::{
-    AuthenticationSpec, Condition, KafkaConnectionSpec, MetricsSpec, PodTemplateSpec,
+    AuthenticationSpec, Condition, KafkaConnectionSpec, LoggingSpec, MetricsSpec, PodTemplateSpec,
     ResourceRequirementsSpec, RestoreInfo, StrimziClusterRef,
 };
 
@@ -43,6 +43,15 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection: Option<KafkaConnectionSpec>,
 
+    /// Logging configuration for restore job pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logging: Option<LoggingSpec>,
+
+    /// Additional environment variables for restore job pods
+    #[schemars(schema_with = "super::common::free_form_object_array")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<serde_json::Value>,
+
     /// Topic mapping for renaming topics during restore
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub topic_mapping: Vec<TopicMappingEntry>,
@@ -67,7 +76,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/jobs/backup_job.rs
+++ b/src/jobs/backup_job.rs
@@ -10,8 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    apply_pod_template, build_annotations, build_labels, build_volumes_and_mounts,
-    job_name_env_var, merge_template_labels,
+    append_env_overrides, apply_pod_template, build_annotations, build_labels,
+    build_volumes_and_mounts, job_name_env_var, merge_template_labels,
 };
 
 /// Build a Kubernetes Job spec for a backup operation
@@ -47,7 +47,7 @@ pub fn build_backup_job(
     env.push(job_name_env_var("BACKUP_ID"));
 
     // Build container
-    let container = Container {
+    let mut container = Container {
         name: "backup".to_string(),
         image: Some(image.to_string()),
         command: Some(vec!["kafka-backup".to_string()]),
@@ -61,6 +61,7 @@ pub fn build_backup_job(
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
     };
+    append_env_overrides(&mut container, &backup.spec.env);
 
     // Build pod spec
     let mut pod_spec = PodSpec {
@@ -132,6 +133,8 @@ mod tests {
             topics: None,
             connection: None,
             consumer_groups: None,
+            logging: None,
+            env: Vec::new(),
             storage: StorageSpec {
                 storage_type: StorageType::S3,
                 s3: Some(S3StorageSpec {

--- a/src/jobs/cronjob.rs
+++ b/src/jobs/cronjob.rs
@@ -10,8 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    apply_pod_template, build_labels, build_volumes_and_mounts, job_name_env_var,
-    merge_template_labels,
+    append_env_overrides, apply_pod_template, build_labels, build_volumes_and_mounts,
+    job_name_env_var, merge_template_labels,
 };
 
 /// Build a Kubernetes CronJob for scheduled backups
@@ -49,7 +49,7 @@ pub fn build_backup_cronjob(
     env.push(job_name_env_var("BACKUP_ID"));
 
     // Build container
-    let container = Container {
+    let mut container = Container {
         name: "backup".to_string(),
         image: Some(image.to_string()),
         command: Some(vec!["kafka-backup".to_string()]),
@@ -63,6 +63,7 @@ pub fn build_backup_cronjob(
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
     };
+    append_env_overrides(&mut container, &backup.spec.env);
 
     // Build pod spec
     let mut pod_spec = PodSpec {

--- a/src/jobs/restore_job.rs
+++ b/src/jobs/restore_job.rs
@@ -10,8 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    apply_pod_template, build_annotations, build_labels, build_volumes_and_mounts,
-    merge_template_labels,
+    append_env_overrides, apply_pod_template, build_annotations, build_labels,
+    build_volumes_and_mounts, merge_template_labels,
 };
 
 /// Build a Kubernetes Job spec for a restore operation
@@ -51,7 +51,7 @@ pub fn build_restore_job(
     );
 
     // Build container
-    let container = Container {
+    let mut container = Container {
         name: "restore".to_string(),
         image: Some(image.to_string()),
         command: Some(vec!["kafka-backup".to_string()]),
@@ -65,6 +65,7 @@ pub fn build_restore_job(
         resources: restore.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
     };
+    append_env_overrides(&mut container, &restore.spec.env);
 
     // Build pod spec
     let mut pod_spec = PodSpec {

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
-    ConfigMapVolumeSource, EnvVar, EnvVarSource, KeyToPath, ObjectFieldSelector, PodSpec,
-    SecretKeySelector, SecretVolumeSource, Volume, VolumeMount,
+    ConfigMapVolumeSource, Container, EnvVar, EnvVarSource, KeyToPath, ObjectFieldSelector,
+    PodSpec, SecretKeySelector, SecretVolumeSource, Volume, VolumeMount,
 };
 
 use crate::crd::common::{
@@ -165,6 +165,24 @@ pub fn job_name_env_var(name: &str) -> EnvVar {
         }),
         ..Default::default()
     }
+}
+
+/// Append pass-through Kubernetes EnvVar objects to a container.
+pub fn append_env_overrides(container: &mut Container, env_values: &[serde_json::Value]) {
+    if env_values.is_empty() {
+        return;
+    }
+
+    let env_vars: Vec<EnvVar> = env_values
+        .iter()
+        .filter_map(|env| serde_json::from_value(env.clone()).ok())
+        .collect();
+    if env_vars.is_empty() {
+        return;
+    }
+
+    let existing_env = container.env.get_or_insert_with(Vec::new);
+    existing_env.extend(env_vars);
 }
 
 fn add_storage_credentials(
@@ -335,15 +353,7 @@ pub fn apply_pod_template(pod_spec: &mut PodSpec, template: Option<&CrdPodTempla
 
     if let Some(container_overrides) = &tmpl.container {
         if let Some(container) = pod_spec.containers.first_mut() {
-            if !container_overrides.env.is_empty() {
-                let env_vars: Vec<k8s_openapi::api::core::v1::EnvVar> = container_overrides
-                    .env
-                    .iter()
-                    .filter_map(|e| serde_json::from_value(e.clone()).ok())
-                    .collect();
-                let existing_env = container.env.get_or_insert_with(Vec::new);
-                existing_env.extend(env_vars);
-            }
+            append_env_overrides(container, &container_overrides.env);
 
             if let Some(sc) = &container_overrides.security_context {
                 if let Ok(s) = serde_json::from_value(sc.clone()) {

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -11,7 +11,7 @@ pub const TRIGGER_VALUE_NOW: &str = "now";
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.
-pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.3";
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.5";
 
 /// Environment variable used by the Helm chart to pass the service account that
 /// backup/restore job pods should run as.

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -21,6 +21,8 @@ fn sample_backup() -> KafkaBackup {
         }),
         connection: None,
         consumer_groups: None,
+        logging: None,
+        env: Vec::new(),
         storage: StorageSpec {
             storage_type: StorageType::S3,
             s3: Some(S3StorageSpec {
@@ -113,8 +115,32 @@ fn test_backup_config_generation() {
 }
 
 #[test]
+fn test_backup_logging_config_generation() {
+    let mut backup = sample_backup();
+    backup.spec.logging = Some(LoggingSpec {
+        level: Some("warn".to_string()),
+        format: Some("json".to_string()),
+        output: None,
+        modules: std::collections::BTreeMap::from([("rdkafka".to_string(), "info".to_string())]),
+        rotation: None,
+    });
+    let cluster = sample_cluster();
+
+    let yaml = build_backup_config_yaml(&backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+
+    assert!(yaml.contains("logging:"));
+    assert!(yaml.contains("level: warn"));
+    assert!(yaml.contains("format: json"));
+    assert!(yaml.contains("rdkafka: info"));
+}
+
+#[test]
 fn test_backup_job_creation() {
-    let backup = sample_backup();
+    let mut backup = sample_backup();
+    backup.spec.env.push(serde_json::json!({
+        "name": "RUST_LOG",
+        "value": "kafka_backup=warn"
+    }));
     let cluster = sample_cluster();
 
     let job = build_backup_job(
@@ -168,11 +194,21 @@ fn test_backup_job_creation() {
         .unwrap()
         .iter()
         .any(|env| env.name == "BACKUP_ID"));
+    assert!(pod_spec.containers[0]
+        .env
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|env| env.name == "RUST_LOG" && env.value.as_deref() == Some("kafka_backup=warn")));
 }
 
 #[test]
 fn test_backup_cronjob_uses_configured_service_account() {
-    let backup = sample_backup();
+    let mut backup = sample_backup();
+    backup.spec.env.push(serde_json::json!({
+        "name": "RUST_LOG",
+        "value": "kafka_backup=debug,rdkafka=info"
+    }));
     let cluster = sample_cluster();
 
     let cronjob = build_backup_cronjob(
@@ -200,6 +236,13 @@ fn test_backup_cronjob_uses_configured_service_account() {
         pod_spec.service_account_name.as_deref(),
         Some("strimzi-backup-operator")
     );
+    assert!(pod_spec.containers[0]
+        .env
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|env| env.name == "RUST_LOG"
+            && env.value.as_deref() == Some("kafka_backup=debug,rdkafka=info")));
 }
 
 #[test]

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -18,6 +18,8 @@ fn sample_backup() -> KafkaBackup {
         topics: None,
         connection: None,
         consumer_groups: None,
+        logging: None,
+        env: Vec::new(),
         storage: StorageSpec {
             storage_type: StorageType::S3,
             s3: Some(S3StorageSpec {
@@ -70,6 +72,8 @@ fn sample_restore() -> KafkaRestore {
             offset_from_end: None,
         }),
         connection: None,
+        logging: None,
+        env: Vec::new(),
         topic_mapping: vec![
             TopicMappingEntry {
                 source_topic: "orders".to_string(),
@@ -154,8 +158,37 @@ fn test_restore_config_generation() {
 }
 
 #[test]
+fn test_restore_logging_config_generation() {
+    let mut restore = sample_restore();
+    restore.spec.logging = Some(LoggingSpec {
+        level: Some("debug".to_string()),
+        format: Some("text".to_string()),
+        output: None,
+        modules: std::collections::BTreeMap::from([(
+            "kafka_backup".to_string(),
+            "debug".to_string(),
+        )]),
+        rotation: None,
+    });
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let yaml =
+        build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+
+    assert!(yaml.contains("logging:"));
+    assert!(yaml.contains("level: debug"));
+    assert!(yaml.contains("format: text"));
+    assert!(yaml.contains("kafka_backup: debug"));
+}
+
+#[test]
 fn test_restore_job_creation() {
-    let restore = sample_restore();
+    let mut restore = sample_restore();
+    restore.spec.env.push(serde_json::json!({
+        "name": "RUST_LOG",
+        "value": "kafka_backup=debug"
+    }));
     let backup = sample_backup();
     let cluster = sample_cluster();
 
@@ -202,6 +235,12 @@ fn test_restore_job_creation() {
         .as_ref()
         .unwrap()
         .contains(&"/config/restore.yaml".to_string()));
+    assert!(pod_spec.containers[0]
+        .env
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|env| env.name == "RUST_LOG" && env.value.as_deref() == Some("kafka_backup=debug")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add first-class `spec.logging` and `spec.env` fields for KafkaBackup and KafkaRestore
- render `spec.logging` into the generated kafka-backup config and append `spec.env` to backup/restore job containers
- bump the default kafka-backup job image to `osodevops/kafka-backup:v0.15.5`
- update README, examples, PRD, generated CRDs, and Helm CRD copies

Fixes #18

## Validation
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `helm template strimzi-backup-operator deploy/helm/strimzi-backup-operator`
- `cargo run --bin crdgen`
- `git diff --check`

## Notes
The default job image was pinned to `v0.15.3`; upstream kafka-backup latest release and Docker tag are now `v0.15.5`, so this PR keeps deterministic pinning while updating to the current v0.15 patch release.