### PR TITLE
chore: use kafka-backup v0.15.6 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.5 - 2026-05-17
+
+### Changed
+
+- Update the default `kafka-backup` job image to `osodevops/kafka-backup:v0.15.6`.
+
 ## 0.2.4 - 2026-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -253,7 +253,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -186,7 +186,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.4
-appVersion: "0.2.4"
+version: 0.2.5
+appVersion: "0.2.5"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -253,7 +253,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -186,7 +186,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
               logging:

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -86,7 +86,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.5)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -76,7 +76,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.5)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -11,7 +11,7 @@ pub const TRIGGER_VALUE_NOW: &str = "now";
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.
-pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.5";
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.6";
 
 /// Environment variable used by the Helm chart to pass the service account that
 /// backup/restore job pods should run as.


### PR DESCRIPTION
## Summary
- bump the Strimzi operator release metadata to `0.2.5`
- update the default backup/restore job image from `osodevops/kafka-backup:v0.15.5` to `osodevops/kafka-backup:v0.15.6`
- regenerate the CRDs so the `spec.image` descriptions show the new default

## Why
Unlike `kafka-backup-operator`, this operator does not link `kafka-backup-core` directly. It creates Jobs/CronJobs that run the `kafka-backup` CLI image, so the core `v0.15.6` fix is only picked up by default after this image bump.

Users can still override `spec.image`, but the default should point at the fixed CLI release.

## Local verification
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo test --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `helm lint deploy/helm/strimzi-backup-operator`
- `helm template test-release deploy/helm/strimzi-backup-operator >/tmp/strimzi-backup-operator-helm.yaml`
- `scripts/release-gate.sh`
- `cargo run --bin crdgen`
- verified generated CRDs match Helm CRDs
