### PR TITLE
feat: support pod host aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.6 - 2026-06-03
+
+### Added
+
+- Add `spec.template.pod.hostAliases` support for `KafkaBackup` and `KafkaRestore` job pods. Fixes [#22](https://github.com/osodevops/strimzi-backup-operator/issues/22).
+
 ## 0.2.5 - 2026-05-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",
@@ -1098,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/bin/crdgen.rs"
 # Kubernetes
 kube = { version = "0.95", features = ["runtime", "derive", "client"] }
 kube-runtime = "0.95"
-k8s-openapi = { version = "0.23", features = ["v1_30"] }
+k8s-openapi = { version = "0.23", features = ["v1_30", "schemars"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full", "signal"] }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The **Kafka Backup Operator** solves these problems with a purpose-built Kuberne
 - **Retention policies** — automatic pruning of old backups by count or age
 - **Compression** — gzip, snappy, lz4, or zstd compression for storage efficiency
 - **Prometheus metrics** — built-in observability with backup/restore counters, duration histograms, and storage gauges
-- **Pod template customisation** — full control over backup/restore Job pods (affinity, tolerations, security context, environment variables)
+- **Pod template customisation** — full control over backup/restore Job pods (affinity, tolerations, host aliases, security context, environment variables)
 - **Azure Workload Identity** — native support for passwordless Azure authentication
 
 ## Architecture

--- a/config/examples/kafka-backup-s3.yaml
+++ b/config/examples/kafka-backup-s3.yaml
@@ -68,3 +68,10 @@ spec:
     limits:
       cpu: "2"
       memory: "4Gi"
+
+  template:
+    pod:
+      hostAliases:
+        - ip: "10.10.0.5"
+          hostnames:
+            - "s3.internal"

--- a/config/examples/kafka-restore-pitr.yaml
+++ b/config/examples/kafka-restore-pitr.yaml
@@ -53,3 +53,10 @@ spec:
     limits:
       cpu: "4"
       memory: "8Gi"
+
+  template:
+    pod:
+      hostAliases:
+        - ip: "10.10.0.5"
+          hostnames:
+            - "s3.internal"

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -667,8 +667,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -678,6 +676,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -709,9 +724,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topics:

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -465,8 +465,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -476,6 +474,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -507,9 +522,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topicMapping:

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.5
-appVersion: "0.2.5"
+version: 0.2.6
+appVersion: "0.2.6"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -667,8 +667,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -678,6 +676,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -709,9 +724,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topics:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -465,8 +465,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -476,6 +474,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -507,9 +522,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topicMapping:

--- a/docs/strimzi-backup-operator-prd.md
+++ b/docs/strimzi-backup-operator-prd.md
@@ -217,6 +217,10 @@ spec:
           prometheus.io/port: "9090"
       affinity: {}
       tolerations: []
+      hostAliases:
+        - ip: "10.10.0.5"
+          hostnames:
+            - "s3.internal"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
@@ -335,6 +339,10 @@ spec:
       metadata:
         labels:
           custom-label: restore-pod
+      hostAliases:
+        - ip: "10.10.0.5"
+          hostnames:
+            - "s3.internal"
 
 status:
   conditions:

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use k8s_openapi::api::core::v1::HostAlias;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -389,7 +390,7 @@ pub struct PodOverrides {
     pub metadata: Option<PodMetadata>,
     /// Pod affinity rules (pass-through to k8s Affinity)
     #[schemars(schema_with = "free_form_object")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub affinity: Option<serde_json::Value>,
     /// Pod tolerations (pass-through to k8s Tolerations)
     #[schemars(schema_with = "free_form_object_array")]
@@ -397,12 +398,15 @@ pub struct PodOverrides {
     pub tolerations: Vec<serde_json::Value>,
     /// Pod security context (pass-through to k8s PodSecurityContext)
     #[schemars(schema_with = "free_form_object")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_context: Option<serde_json::Value>,
     /// Image pull secrets
     #[schemars(schema_with = "free_form_object_array")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub image_pull_secrets: Vec<serde_json::Value>,
+    /// Pod host aliases (pass-through to k8s HostAlias)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub host_aliases: Vec<HostAlias>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
@@ -425,7 +429,7 @@ pub struct ContainerOverrides {
     pub env: Vec<serde_json::Value>,
     /// Container security context (pass-through to k8s SecurityContext)
     #[schemars(schema_with = "free_form_object")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_context: Option<serde_json::Value>,
 }
 

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -349,6 +349,10 @@ pub fn apply_pod_template(pod_spec: &mut PodSpec, template: Option<&CrdPodTempla
                 pod_spec.image_pull_secrets = Some(secrets);
             }
         }
+
+        if !pod_overrides.host_aliases.is_empty() {
+            pod_spec.host_aliases = Some(pod_overrides.host_aliases.clone());
+        }
     }
 
     if let Some(container_overrides) = &tmpl.container {

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -1,3 +1,4 @@
+use k8s_openapi::api::core::v1::HostAlias;
 use kafka_backup_operator::adapters::backup_config::build_backup_config_yaml;
 use kafka_backup_operator::crd::common::*;
 use kafka_backup_operator::crd::kafka_backup::*;
@@ -92,6 +93,22 @@ fn sample_cluster() -> ResolvedKafkaCluster {
         replicas: 3,
         tls_enabled: true,
         listener_name: "tls".to_string(),
+    }
+}
+
+fn host_alias_template() -> PodTemplateSpec {
+    PodTemplateSpec {
+        pod: Some(PodOverrides {
+            host_aliases: vec![HostAlias {
+                ip: "10.10.0.5".to_string(),
+                hostnames: Some(vec![
+                    "s3.internal".to_string(),
+                    "minio.internal".to_string(),
+                ]),
+            }],
+            ..Default::default()
+        }),
+        container: None,
     }
 }
 
@@ -243,6 +260,61 @@ fn test_backup_cronjob_uses_configured_service_account() {
         .iter()
         .any(|env| env.name == "RUST_LOG"
             && env.value.as_deref() == Some("kafka_backup=debug,rdkafka=info")));
+}
+
+#[test]
+fn test_backup_jobs_apply_template_host_aliases() {
+    let mut backup = sample_backup();
+    backup.spec.template = Some(host_alias_template());
+    let cluster = sample_cluster();
+
+    let job = build_backup_job(
+        &backup,
+        "daily-backup-20260213-020000",
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+
+    let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    let host_aliases = pod_spec.host_aliases.as_ref().unwrap();
+    assert_eq!(host_aliases.len(), 1);
+    assert_eq!(host_aliases[0].ip, "10.10.0.5");
+    assert_eq!(
+        host_aliases[0].hostnames.as_ref().unwrap(),
+        &vec!["s3.internal".to_string(), "minio.internal".to_string()]
+    );
+
+    let cronjob = build_backup_cronjob(
+        &backup,
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+
+    let cron_pod_spec = cronjob
+        .spec
+        .as_ref()
+        .unwrap()
+        .job_template
+        .spec
+        .as_ref()
+        .unwrap()
+        .template
+        .spec
+        .as_ref()
+        .unwrap();
+    let cron_host_aliases = cron_pod_spec.host_aliases.as_ref().unwrap();
+    assert_eq!(cron_host_aliases.len(), 1);
+    assert_eq!(cron_host_aliases[0].ip, "10.10.0.5");
+    assert_eq!(
+        cron_host_aliases[0].hostnames.as_ref().unwrap(),
+        &vec!["s3.internal".to_string(), "minio.internal".to_string()]
+    );
 }
 
 #[test]

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -1,3 +1,4 @@
+use k8s_openapi::api::core::v1::HostAlias;
 use kafka_backup_operator::adapters::restore_config::build_restore_config_yaml;
 use kafka_backup_operator::crd::common::*;
 use kafka_backup_operator::crd::kafka_backup::*;
@@ -136,6 +137,22 @@ fn sample_cluster() -> ResolvedKafkaCluster {
     }
 }
 
+fn host_alias_template() -> PodTemplateSpec {
+    PodTemplateSpec {
+        pod: Some(PodOverrides {
+            host_aliases: vec![HostAlias {
+                ip: "10.10.0.6".to_string(),
+                hostnames: Some(vec![
+                    "s3.internal".to_string(),
+                    "backup-storage.internal".to_string(),
+                ]),
+            }],
+            ..Default::default()
+        }),
+        container: None,
+    }
+}
+
 #[test]
 fn test_restore_config_generation() {
     let restore = sample_restore();
@@ -241,6 +258,37 @@ fn test_restore_job_creation() {
         .unwrap()
         .iter()
         .any(|env| env.name == "RUST_LOG" && env.value.as_deref() == Some("kafka_backup=debug")));
+}
+
+#[test]
+fn test_restore_job_applies_template_host_aliases() {
+    let mut restore = sample_restore();
+    restore.spec.template = Some(host_alias_template());
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let job = build_restore_job(
+        &restore,
+        "pitr-restore-20260213-093000",
+        "pitr-restore-config",
+        &cluster,
+        &ResolvedAuth::None,
+        &backup,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+
+    let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    let host_aliases = pod_spec.host_aliases.as_ref().unwrap();
+    assert_eq!(host_aliases.len(), 1);
+    assert_eq!(host_aliases[0].ip, "10.10.0.6");
+    assert_eq!(
+        host_aliases[0].hostnames.as_ref().unwrap(),
+        &vec![
+            "s3.internal".to_string(),
+            "backup-storage.internal".to_string()
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `spec.template.pod.hostAliases` support for KafkaBackup and KafkaRestore pods
- use typed Kubernetes `HostAlias` schema validation instead of a free-form pass-through array
- apply aliases to one-shot backup Jobs, scheduled backup CronJobs, and restore Jobs
- regenerate CRDs and update examples/docs/changelog

Fixes #22.

## Validation
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `helm template --include-crds strimzi-backup-operator deploy/helm/strimzi-backup-operator`
- `helm lint deploy/helm/strimzi-backup-operator`
- `git diff --check`
- minikube API-server validation for valid and invalid `hostAliases`
- live local operator reconcile validated generated Job and CronJob pod templates
- runtime canary pod validated Kubernetes `/etc/hosts` injection
