### PR TITLE
feat: restore topic selection and per-CR job service account (0.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.8 - 2026-06-11
+
+### Added
+
+- Add `spec.topics` with include/exclude glob (or `~`-prefixed regex) patterns to `KafkaRestore`, allowing specific topics to be restored from a backup. Fixes [#26](https://github.com/osodevops/strimzi-backup-operator/issues/26).
+- Add `spec.template.pod.serviceAccountName` to `KafkaBackup` and `KafkaRestore` so job pods in namespaces other than the operator's can run with a service account that exists there. Fixes [#27](https://github.com/osodevops/strimzi-backup-operator/issues/27).
+
 ## 0.2.7 - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ The **Kafka Backup Operator** solves these problems with a purpose-built Kuberne
 - **Scheduled backups** — cron-based scheduling with timezone support via Kubernetes CronJobs
 - **Point-in-time recovery (PITR)** — restore your Kafka cluster to any millisecond-precision timestamp
 - **Multi-cloud storage** — back up to Amazon S3, Azure Blob Storage, Google Cloud Storage, or any S3-compatible store (MinIO, Ceph RGW)
-- **Topic filtering** — include/exclude topics using regex patterns
+- **Topic filtering** — include/exclude topics using glob or regex patterns, for both backup and restore
 - **Topic mapping** — rename topics during restore for migration or testing scenarios
 - **Consumer group offset restore** — restore consumer group offsets with optional group remapping
 - **Retention policies** — automatic pruning of old backups by count or age
 - **Compression** — gzip, snappy, lz4, or zstd compression for storage efficiency
 - **Prometheus metrics** — built-in observability with backup/restore counters, duration histograms, and storage gauges
-- **Pod template customisation** — full control over backup/restore Job pods (affinity, tolerations, host aliases, security context, environment variables)
+- **Pod template customisation** — full control over backup/restore Job pods (affinity, tolerations, host aliases, service account, security context, environment variables)
 - **Azure Workload Identity** — native support for passwordless Azure authentication
 
 ## Architecture
@@ -148,6 +148,11 @@ spec:
     name: my-cluster
   backupRef:
     name: my-cluster-backup
+  topics:
+    include:
+      - "orders-*"          # glob, or "~orders-\d+" for regex
+    exclude:
+      - "*-internal"
   pointInTime:
     timestamp: "2026-02-12T14:30:00.000Z"
   logging:
@@ -293,6 +298,26 @@ spec:
 | `resources.requests.memory` | Memory request | `128Mi` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
+
+### Job service accounts across namespaces
+
+Backup and restore Jobs run in the namespace of the `KafkaBackup`/`KafkaRestore`
+resource, and by default reference the service account named by
+`backupJobs.serviceAccountName` (falling back to the operator's own service
+account). Service accounts are namespace-scoped, so for resources created
+outside the operator's namespace, set `spec.template.pod.serviceAccountName`
+to a service account that exists in that namespace:
+
+```yaml
+spec:
+  template:
+    pod:
+      serviceAccountName: kafka-backup-jobs
+```
+
+The service account only needs to exist (job pods don't call the Kubernetes
+API), but it should carry any workload-identity annotations (IRSA, Azure
+Workload Identity) your storage backend requires.
 
 ## Logging
 

--- a/config/examples/kafka-restore-pitr.yaml
+++ b/config/examples/kafka-restore-pitr.yaml
@@ -18,6 +18,14 @@ spec:
     name: daily-backup
     backupId: "backup-20260213-020000"
 
+  # Restore only selected topics from the backup. Glob patterns by default;
+  # prefix with ~ for regex. Matched against source topic names, before
+  # topicMapping renames. Omit to restore every topic in the backup.
+  topics:
+    include:
+      - "orders"
+      - "payments"
+
   pointInTime:
     timestamp: "2026-02-13T01:30:00.000Z"
 
@@ -56,6 +64,9 @@ spec:
 
   template:
     pod:
+      # Service account for the restore job pod; must exist in this namespace.
+      # Defaults to the operator-wide backupJobs.serviceAccountName.
+      serviceAccountName: kafka-backup-jobs
       hostAliases:
         - ip: "10.10.0.5"
           hostnames:

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -718,6 +718,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -516,6 +516,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:
@@ -540,6 +544,21 @@ spec:
                   - targetTopic
                   type: object
                 type: array
+              topics:
+                description: Topics to restore, selected by include/exclude glob (or `~`-prefixed regex) patterns matched against source topic names in the backup. All topics are restored when omitted. Filtering is applied before topicMapping renames.
+                nullable: true
+                properties:
+                  exclude:
+                    description: Glob patterns for topics to exclude
+                    items:
+                      type: string
+                    type: array
+                  include:
+                    description: Glob patterns for topics to include
+                    items:
+                      type: string
+                    type: array
+                type: object
             required:
             - backupRef
             - strimziClusterRef

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.7
-appVersion: "0.2.7"
+version: 0.2.8
+appVersion: "0.2.8"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -718,6 +718,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -516,6 +516,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:
@@ -540,6 +544,21 @@ spec:
                   - targetTopic
                   type: object
                 type: array
+              topics:
+                description: Topics to restore, selected by include/exclude glob (or `~`-prefixed regex) patterns matched against source topic names in the backup. All topics are restored when omitted. Filtering is applied before topicMapping renames.
+                nullable: true
+                properties:
+                  exclude:
+                    description: Glob patterns for topics to exclude
+                    items:
+                      type: string
+                    type: array
+                  include:
+                    description: Glob patterns for topics to include
+                    items:
+                      type: string
+                    type: array
+                type: object
             required:
             - backupRef
             - strimziClusterRef

--- a/deploy/helm/strimzi-backup-operator/values.yaml
+++ b/deploy/helm/strimzi-backup-operator/values.yaml
@@ -25,8 +25,11 @@ serviceAccount:
   name: ""
 
 backupJobs:
-  # Service account used by backup and restore job pods.
+  # Default service account used by backup and restore job pods.
   # If empty, the chart passes the operator service account name.
+  # The account must exist in each namespace where KafkaBackup/KafkaRestore
+  # resources are created; individual resources can override it with
+  # spec.template.pod.serviceAccountName.
   serviceAccountName: ""
 
 # Azure Workload Identity configuration

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -286,7 +286,7 @@ fn build_backup_options(opts: &crate::crd::kafka_backup::BackupOptionsSpec) -> R
     Ok(Value::Mapping(config))
 }
 
-fn build_topic_selection(topics: &crate::crd::common::TopicSelection) -> Value {
+pub(crate) fn build_topic_selection(topics: &crate::crd::common::TopicSelection) -> Value {
     let mut topic_config = serde_yaml::Mapping::new();
     if !topics.include.is_empty() {
         topic_config.insert(

--- a/src/adapters/restore_config.rs
+++ b/src/adapters/restore_config.rs
@@ -6,6 +6,7 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 use crate::strimzi::tls::ResolvedTlsCerts;
 
+use super::backup_config::build_topic_selection;
 use super::logging_config::build_logging_config;
 use super::storage_config::build_storage_config;
 
@@ -32,7 +33,13 @@ pub fn build_restore_config_yaml(
     );
 
     // Target (Kafka cluster)
-    let target = build_kafka_config(cluster, tls_certs, auth, restore.spec.connection.as_ref())?;
+    let target = build_kafka_config(
+        cluster,
+        tls_certs,
+        auth,
+        restore.spec.topics.as_ref(),
+        restore.spec.connection.as_ref(),
+    )?;
     config.insert(Value::String("target".to_string()), target);
 
     // Storage (from source backup CR)
@@ -75,6 +82,7 @@ fn build_kafka_config(
     cluster: &ResolvedKafkaCluster,
     _tls_certs: &Option<ResolvedTlsCerts>,
     auth: &ResolvedAuth,
+    topics: Option<&crate::crd::common::TopicSelection>,
     connection: Option<&crate::crd::common::KafkaConnectionSpec>,
 ) -> Result<Value> {
     let mut kafka = serde_yaml::Mapping::new();
@@ -136,6 +144,15 @@ fn build_kafka_config(
         Value::String("security".to_string()),
         Value::Mapping(security),
     );
+
+    if let Some(topics) = topics {
+        let topic_config = build_topic_selection(topics);
+        if let Value::Mapping(ref m) = topic_config {
+            if !m.is_empty() {
+                kafka.insert(Value::String("topics".to_string()), topic_config);
+            }
+        }
+    }
 
     if let Some(connection) = connection {
         let connection_config = build_connection_config(connection);

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -407,6 +407,10 @@ pub struct PodOverrides {
     /// Pod host aliases (pass-through to k8s HostAlias)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub host_aliases: Vec<HostAlias>,
+    /// Service account for job pods. Must exist in the namespace of this resource.
+    /// Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_account_name: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{
     AuthenticationSpec, Condition, KafkaConnectionSpec, LoggingSpec, MetricsSpec, PodTemplateSpec,
-    ResourceRequirementsSpec, RestoreInfo, StrimziClusterRef,
+    ResourceRequirementsSpec, RestoreInfo, StrimziClusterRef, TopicSelection,
 };
 
 /// KafkaRestore defines a restore operation from a KafkaBackup to a Strimzi-managed Kafka cluster.
@@ -34,6 +34,12 @@ pub struct KafkaRestoreSpec {
 
     /// Reference to the source backup
     pub backup_ref: BackupRef,
+
+    /// Topics to restore, selected by include/exclude glob (or `~`-prefixed regex)
+    /// patterns matched against source topic names in the backup. All topics are
+    /// restored when omitted. Filtering is applied before topicMapping renames.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topics: Option<TopicSelection>,
 
     /// Point-in-time recovery settings
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -353,6 +353,13 @@ pub fn apply_pod_template(pod_spec: &mut PodSpec, template: Option<&CrdPodTempla
         if !pod_overrides.host_aliases.is_empty() {
             pod_spec.host_aliases = Some(pod_overrides.host_aliases.clone());
         }
+
+        if let Some(sa) = &pod_overrides.service_account_name {
+            let sa = sa.trim();
+            if !sa.is_empty() {
+                pod_spec.service_account_name = Some(sa.to_string());
+            }
+        }
     }
 
     if let Some(container_overrides) = &tmpl.container {

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -390,3 +390,77 @@ fn test_backup_with_tls_auth() {
         .unwrap();
     assert!(volumes.iter().any(|v| v.name == "user-certs"));
 }
+
+#[test]
+fn test_backup_jobs_apply_template_service_account() {
+    let mut backup = sample_backup();
+    backup.spec.template = Some(PodTemplateSpec {
+        pod: Some(PodOverrides {
+            service_account_name: Some("backup-jobs".to_string()),
+            ..Default::default()
+        }),
+        container: None,
+    });
+    let cluster = sample_cluster();
+
+    let job = build_backup_job(
+        &backup,
+        "daily-backup-20260213-020000",
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+    let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("backup-jobs")
+    );
+
+    let cronjob = build_backup_cronjob(
+        &backup,
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+    let cron_pod_spec = cronjob
+        .spec
+        .as_ref()
+        .unwrap()
+        .job_template
+        .spec
+        .as_ref()
+        .unwrap()
+        .template
+        .spec
+        .as_ref()
+        .unwrap();
+    assert_eq!(
+        cron_pod_spec.service_account_name.as_deref(),
+        Some("backup-jobs")
+    );
+}
+
+#[test]
+fn test_backup_job_falls_back_to_operator_service_account() {
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let job = build_backup_job(
+        &backup,
+        "daily-backup-20260213-020000",
+        "daily-backup-config",
+        &cluster,
+        &ResolvedAuth::None,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+    let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("strimzi-backup-operator")
+    );
+}

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -63,6 +63,7 @@ fn sample_restore() -> KafkaRestore {
             ca_secret: None,
         },
         authentication: None,
+        topics: None,
         backup_ref: BackupRef {
             name: "daily-backup".to_string(),
             backup_id: Some("backup-20260213-020000".to_string()),
@@ -325,4 +326,69 @@ fn test_restore_with_unsupported_existing_topic_fail_policy() {
     assert!(err
         .to_string()
         .contains("existingTopicPolicy: fail is not supported"));
+}
+
+#[test]
+fn test_restore_config_topic_selection() {
+    let mut restore = sample_restore();
+    restore.spec.topics = Some(TopicSelection {
+        include: vec!["orders-*".to_string(), "~payments-\\d+".to_string()],
+        exclude: vec!["*-internal".to_string()],
+    });
+
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let yaml =
+        build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+
+    let config: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+    let topics = &config["target"]["topics"];
+    assert_eq!(topics["include"][0].as_str(), Some("orders-*"));
+    assert_eq!(topics["include"][1].as_str(), Some("~payments-\\d+"));
+    assert_eq!(topics["exclude"][0].as_str(), Some("*-internal"));
+}
+
+#[test]
+fn test_restore_config_omits_topic_selection_by_default() {
+    let restore = sample_restore();
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let yaml =
+        build_restore_config_yaml(&restore, &backup, &cluster, &None, &ResolvedAuth::None).unwrap();
+
+    let config: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+    assert!(config["target"].get("topics").is_none());
+}
+
+#[test]
+fn test_restore_job_applies_template_service_account() {
+    let mut restore = sample_restore();
+    restore.spec.template = Some(PodTemplateSpec {
+        pod: Some(PodOverrides {
+            service_account_name: Some("restore-jobs".to_string()),
+            ..Default::default()
+        }),
+        container: None,
+    });
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+
+    let job = build_restore_job(
+        &restore,
+        "pitr-restore-20260213-093000",
+        "pitr-restore-config",
+        &cluster,
+        &ResolvedAuth::None,
+        &backup,
+        Some("strimzi-backup-operator"),
+    )
+    .unwrap();
+
+    let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+    assert_eq!(
+        pod_spec.service_account_name.as_deref(),
+        Some("restore-jobs")
+    );
 }


### PR DESCRIPTION
## Summary

Two additive CRD features, released together as 0.2.8:

### `KafkaRestore.spec.topics` — restore specific topics (#26)

The kafka-backup CLI has always honoured `target.topics` include/exclude filtering on restore, but the operator never exposed it — every restore pulled all topics from the backup. `KafkaRestore` now accepts the same `TopicSelection` the `KafkaBackup` CRD uses:

```yaml
spec:
  topics:
    include:
      - "orders-*"          # glob, or "~orders-\d+" for regex
    exclude:
      - "*-internal"
```

Patterns match **source** topic names in the backup manifest, before `topicMapping` renames. Omitted = restore everything (unchanged default). Verified the pinned default image (`kafka-backup:v0.15.6`) supports this on both restore paths.

### `spec.template.pod.serviceAccountName` on both CRDs (#27)

Backup/restore Jobs run in the CR's namespace but always referenced the operator-wide service account (`BACKUP_JOB_SERVICE_ACCOUNT`). Service accounts are namespace-scoped, so any CR outside the operator's namespace produced Jobs whose pods could never be created:

```
Error creating: pods "..." is forbidden: error looking up service account
kafka/strimzi-backup-operator: serviceaccount "strimzi-backup-operator" not found
```

Both CRDs now accept a per-resource override that takes precedence over the operator-wide default, applied uniformly to backup Jobs, restore Jobs, and scheduled CronJobs:

```yaml
spec:
  template:
    pod:
      serviceAccountName: kafka-backup-jobs   # must exist in the CR's namespace
```

## Compatibility

- Both fields are optional; omitting them produces byte-identical configs and job specs to 0.2.7.
- `helm template` output is unchanged for existing values (default and custom `backupJobs.serviceAccountName`).
- The chart-bundled CRDs (`deploy/helm/.../crds/`) are synced with the regenerated `deploy/crds/`. As usual, Helm only installs CRDs on first install — existing deployments should `kubectl apply -f deploy/crds/` when upgrading.

## Verification

- 46 cargo tests pass, including new builder- and config-level tests: topic selection emitted / omitted by default; SA override on Job, CronJob, and restore Job; fallback to the operator SA. `cargo fmt --check`, clippy (zero warnings), `helm lint`, and `scripts/release-gate.sh` all pass.
- End-to-end in a kind cluster with this branch's image helm-installed into `backup-system`:
  - `KafkaBackup`/`KafkaRestore` in a different namespace (`kafka`) with the SA override: Jobs created with the per-CR SA, pods scheduled (`SuccessfulCreate`) — previously a hard `FailedCreate`.
  - A CR in the operator's own namespace without the override still uses the operator SA — no regression for single-namespace installs.
  - Generated restore ConfigMap contains `target.topics` with the include/exclude lists; a `spec.topics` manifest that the API server previously rejected with `unknown field` now validates.

## Follow-up (not in this PR)

A missing service account currently leaves the CR reporting the job as running while the Job controller retries pod creation forever. Worth a separate issue: surface `FailedCreate` Job events as a `Ready=False` condition.

Fixes #26. Fixes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)