### PR TITLE
fix: SCRAM-SHA-512 auth fails due to invalid sasl_mechanism in generated config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.11 - 2026-07-03
+
+### Fixed
+
+- Write `sasl_mechanism: SCRAM-SHA512` (no hyphen before the digits) into generated backup and restore ConfigMaps. The kafka-backup binary's config parser only accepts `SCRAM-SHA512`, so jobs for resources using `authentication.type: scram-sha-512` failed on startup with `unknown variant 'SCRAM-SHA-512'`. Fixes [#35](https://github.com/osodevops/strimzi-backup-operator/issues/35).
+
 ## 0.2.10 - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.10
-appVersion: "0.2.10"
+version: 0.2.11
+appVersion: "0.2.11"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -150,7 +150,7 @@ fn build_kafka_config(
         } => {
             security.insert(
                 Value::String("sasl_mechanism".to_string()),
-                Value::String("SCRAM-SHA-512".to_string()),
+                Value::String(super::SASL_MECHANISM_SCRAM_SHA512.to_string()),
             );
             security.insert(
                 Value::String("sasl_username".to_string()),
@@ -558,6 +558,25 @@ mod tests {
         assert!(yaml.contains("output: stderr"));
         assert!(yaml.contains("kafka_backup: debug"));
         assert!(yaml.contains("rdkafka: info"));
+    }
+
+    /// Issue #35: the kafka-backup binary's config parser only accepts
+    /// `SCRAM-SHA512` (no hyphen before the digits); `SCRAM-SHA-512` is
+    /// rejected with "unknown variant".
+    #[test]
+    fn test_scram_auth_emits_binary_compatible_sasl_mechanism() {
+        let backup = test_backup();
+        let auth = ResolvedAuth::ScramSha512 {
+            username: "kafka-backup".to_string(),
+            secret_name: "kafka-backup".to_string(),
+            password_key: "password".to_string(),
+        };
+        let yaml = build_backup_config_yaml(&backup, &test_cluster(), &None, &auth).unwrap();
+        let config: Value = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(
+            config["source"]["security"]["sasl_mechanism"].as_str(),
+            Some("SCRAM-SHA512")
+        );
     }
 
     #[test]

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -3,3 +3,9 @@ pub mod logging_config;
 pub mod restore_config;
 pub mod secrets;
 pub mod storage_config;
+
+/// SASL mechanism value for SCRAM-SHA-512 as the kafka-backup binary's config
+/// parser expects it: `SCRAM-SHA512`, with no hyphen before the digits. The
+/// binary rejects the IANA spelling `SCRAM-SHA-512` with "unknown variant"
+/// (issue #35).
+pub(crate) const SASL_MECHANISM_SCRAM_SHA512: &str = "SCRAM-SHA512";

--- a/src/adapters/restore_config.rs
+++ b/src/adapters/restore_config.rs
@@ -126,7 +126,7 @@ fn build_kafka_config(
         ResolvedAuth::ScramSha512 { username, .. } => {
             security.insert(
                 Value::String("sasl_mechanism".to_string()),
-                Value::String("SCRAM-SHA-512".to_string()),
+                Value::String(super::SASL_MECHANISM_SCRAM_SHA512.to_string()),
             );
             security.insert(
                 Value::String("sasl_username".to_string()),

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -351,6 +351,33 @@ fn test_restore_config_topic_selection() {
     assert_eq!(topics["exclude"][0].as_str(), Some("*-internal"));
 }
 
+/// Issue #35: the kafka-backup binary's config parser only accepts
+/// `SCRAM-SHA512` (no hyphen before the digits); `SCRAM-SHA-512` is
+/// rejected with "unknown variant".
+#[test]
+fn test_restore_scram_auth_emits_binary_compatible_sasl_mechanism() {
+    let restore = sample_restore();
+    let backup = sample_backup();
+    let cluster = sample_cluster();
+    let auth = ResolvedAuth::ScramSha512 {
+        username: "kafka-backup".to_string(),
+        secret_name: "kafka-backup".to_string(),
+        password_key: "password".to_string(),
+    };
+
+    let yaml = build_restore_config_yaml(&restore, &backup, &cluster, &None, &auth).unwrap();
+
+    let config: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(
+        config["target"]["security"]["sasl_mechanism"].as_str(),
+        Some("SCRAM-SHA512")
+    );
+    assert_eq!(
+        config["target"]["security"]["security_protocol"].as_str(),
+        Some("SASL_SSL")
+    );
+}
+
 #[test]
 fn test_restore_config_omits_topic_selection_by_default() {
     let restore = sample_restore();


### PR DESCRIPTION
Fixes #35

## Problem

Backup and restore jobs for resources using `authentication.type: scram-sha-512` fail immediately on startup:

```
Error: source.security.sasl_mechanism: unknown variant `SCRAM-SHA-512`, expected one of `PLAIN`, `SCRAM-SHA256`, `SCRAM-SHA512`, `GSSAPI`
```

Both config adapters wrote the CRD-style value `SCRAM-SHA-512` verbatim into the generated ConfigMap, but the kafka-backup binary's config parser only accepts `SCRAM-SHA512` (no hyphen before the digits).

## Fix

- `src/adapters/backup_config.rs` and `src/adapters/restore_config.rs` now emit `SCRAM-SHA512`, sourced from a single shared constant (`SASL_MECHANISM_SCRAM_SHA512` in `src/adapters/mod.rs`) so the two adapters can't drift apart again.
- Unit + integration tests pin the emitted value for both the backup (`source.security`) and restore (`target.security`) paths. Written test-first: both failed with `SCRAM-SHA-512` before the fix.

The CRD-facing value `scram-sha-512` is unchanged — this only fixes the translation to the binary's config format. `scram-sha-256` is not affected because the operator only supports `tls` and `scram-sha-512` authentication types.

## Reproduction

Running `osodevops/kafka-backup:v0.15.6` directly against a config with `sasl_mechanism: SCRAM-SHA-512` reproduces the exact parse error from the issue; `SCRAM-SHA512` parses cleanly.

## End-to-end verification (kind)

Strimzi 0.46.1, Kafka with a SCRAM-SHA-512 listener, KafkaUser, MinIO as S3, operator built from this branch:

1. `KafkaBackup` with `authentication.type: scram-sha-512` → generated ConfigMap contains `sasl_mechanism: SCRAM-SHA512`, backup Job completes, 100 records from `orders` land in the MinIO bucket, CR reports `Ready/BackupCompleted`.
2. `KafkaRestore` from that backup with the same auth and `topicMapping: orders → orders-restored` → restore Job completes, CR reports `RestoreCompleted`, and a SCRAM consumer reads all 100 records from `orders-restored`.

## Release

- Version bumped 0.2.10 → 0.2.11 (Cargo.toml, Cargo.lock, Chart.yaml version + appVersion), CHANGELOG entry added; `scripts/release-gate.sh` passes.
- No CRD changes.

## Note for maintainers (out of scope)

While setting up the e2e I noticed the operator resolves the Strimzi `Kafka` CR via API version `v1beta2` (`src/strimzi/kafka_cr.rs`). Strimzi 1.x serves only `kafka.strimzi.io/v1`, so the operator cannot resolve clusters on Strimzi 1.x — worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)