### PR TITLE
fix: support Strimzi v1 resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.13 - 2026-07-10
+
+### Fixed
+
+- Resolve Strimzi `Kafka` and `KafkaUser` resources through the stable `kafka.strimzi.io/v1` API required by Strimzi 1.0 and later. The operator falls back to `v1beta2` on a not-found response so existing installations running older Strimzi releases remain supported. Fixes [#39](https://github.com/osodevops/strimzi-backup-operator/issues/39).
+
 ## 0.2.12 - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The Kafka Backup Operator creates Kubernetes Jobs (or CronJobs for scheduled bac
 ### Prerequisites
 
 - Kubernetes 1.27+
-- [Strimzi Cluster Operator](https://strimzi.io/) installed with a running Kafka cluster
+- [Strimzi Cluster Operator](https://strimzi.io/) installed with a running Kafka cluster (`kafka.strimzi.io/v1` and legacy `v1beta2` resources are supported)
 - Helm 3.x
 
 ### Install with Helm

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.12
-appVersion: "0.2.12"
+version: 0.2.13
+appVersion: "0.2.13"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/src/strimzi/kafka_cr.rs
+++ b/src/strimzi/kafka_cr.rs
@@ -1,11 +1,10 @@
-use kube::{
-    api::{Api, DynamicObject, GroupVersionKind},
-    Client, ResourceExt,
-};
+use kube::{api::DynamicObject, Client, ResourceExt};
 use tracing::{debug, info};
 
 use crate::crd::common::{AuthenticationType, StrimziClusterRef};
 use crate::error::{Error, Result};
+
+use super::resource::get_namespaced_resource;
 
 /// Resolved information from a Strimzi Kafka CR
 #[derive(Clone, Debug)]
@@ -43,23 +42,15 @@ pub async fn resolve_kafka_cluster(
 
     info!(%name, %namespace, "Resolving Strimzi Kafka cluster");
 
-    let api: Api<DynamicObject> = Api::namespaced_with(
-        client.clone(),
-        namespace,
-        &kube::api::ApiResource::from_gvk(&GroupVersionKind::gvk(
-            "kafka.strimzi.io",
-            "v1beta2",
-            "Kafka",
-        )),
-    );
-
-    let kafka = api.get(name).await.map_err(|e| match &e {
-        kube::Error::Api(ae) if ae.code == 404 => Error::StrimziClusterNotFound {
-            name: name.clone(),
-            namespace: namespace.to_string(),
-        },
-        _ => Error::Kube(e),
-    })?;
+    let kafka = get_namespaced_resource(client, namespace, "Kafka", name)
+        .await
+        .map_err(|e| match &e {
+            kube::Error::Api(ae) if ae.code == 404 => Error::StrimziClusterNotFound {
+                name: name.clone(),
+                namespace: namespace.to_string(),
+            },
+            _ => Error::Kube(e),
+        })?;
 
     let connection = resolve_connection(
         &kafka,
@@ -297,7 +288,7 @@ fn extract_replicas(kafka: &DynamicObject) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kube::api::ApiResource;
+    use kube::api::{ApiResource, GroupVersionKind};
     use serde_json::json;
 
     fn kafka_fixture(

--- a/src/strimzi/kafka_user.rs
+++ b/src/strimzi/kafka_user.rs
@@ -1,11 +1,10 @@
-use kube::{
-    api::{Api, DynamicObject, GroupVersionKind},
-    Client,
-};
+use kube::Client;
 use tracing::{debug, info};
 
 use crate::crd::common::{AuthenticationSpec, AuthenticationType};
 use crate::error::{Error, Result};
+
+use super::resource::get_namespaced_resource;
 
 /// Resolved authentication credentials
 #[derive(Clone, Debug)]
@@ -112,23 +111,15 @@ async fn resolve_kafka_user_secret(
 ) -> Result<String> {
     info!(%user_name, %namespace, "Resolving KafkaUser secret");
 
-    let api: Api<DynamicObject> = Api::namespaced_with(
-        client.clone(),
-        namespace,
-        &kube::api::ApiResource::from_gvk(&GroupVersionKind::gvk(
-            "kafka.strimzi.io",
-            "v1beta2",
-            "KafkaUser",
-        )),
-    );
-
-    let user = api.get(user_name).await.map_err(|e| match &e {
-        kube::Error::Api(ae) if ae.code == 404 => Error::KafkaUserNotFound {
-            name: user_name.to_string(),
-            namespace: namespace.to_string(),
-        },
-        _ => Error::Kube(e),
-    })?;
+    let user = get_namespaced_resource(client, namespace, "KafkaUser", user_name)
+        .await
+        .map_err(|e| match &e {
+            kube::Error::Api(ae) if ae.code == 404 => Error::KafkaUserNotFound {
+                name: user_name.to_string(),
+                namespace: namespace.to_string(),
+            },
+            _ => Error::Kube(e),
+        })?;
 
     // Check if status.secret is set
     if let Some(status) = user.data.get("status") {

--- a/src/strimzi/mod.rs
+++ b/src/strimzi/mod.rs
@@ -1,3 +1,4 @@
 pub mod kafka_cr;
 pub mod kafka_user;
+mod resource;
 pub mod tls;

--- a/src/strimzi/resource.rs
+++ b/src/strimzi/resource.rs
@@ -1,0 +1,55 @@
+use kube::{
+    api::{Api, ApiResource, DynamicObject, GroupVersionKind},
+    Client,
+};
+use tracing::debug;
+
+const STRIMZI_GROUP: &str = "kafka.strimzi.io";
+const PREFERRED_API_VERSION: &str = "v1";
+const LEGACY_API_VERSION: &str = "v1beta2";
+
+/// Get a namespaced Strimzi resource using the stable API, falling back to the
+/// legacy API served by Strimzi releases older than 0.49.
+///
+/// Strimzi 0.49 through 0.51 serve both versions, while Strimzi 1.0 serves only
+/// `v1`. A 404 can mean either that the API version is not served or that the
+/// named resource is absent, so retrying the legacy endpoint is safe. Other
+/// errors (such as authorization or transport failures) are returned directly.
+pub(crate) async fn get_namespaced_resource(
+    client: &Client,
+    namespace: &str,
+    kind: &str,
+    name: &str,
+) -> Result<DynamicObject, kube::Error> {
+    match get_at_version(client, namespace, kind, name, PREFERRED_API_VERSION).await {
+        Ok(resource) => Ok(resource),
+        Err(error) if is_not_found(&error) => {
+            debug!(
+                %kind,
+                %name,
+                %namespace,
+                version = PREFERRED_API_VERSION,
+                fallback_version = LEGACY_API_VERSION,
+                "Strimzi resource not found at preferred API version; trying legacy API"
+            );
+            get_at_version(client, namespace, kind, name, LEGACY_API_VERSION).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn get_at_version(
+    client: &Client,
+    namespace: &str,
+    kind: &str,
+    name: &str,
+    version: &str,
+) -> Result<DynamicObject, kube::Error> {
+    let resource = ApiResource::from_gvk(&GroupVersionKind::gvk(STRIMZI_GROUP, version, kind));
+    let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), namespace, &resource);
+    api.get(name).await
+}
+
+fn is_not_found(error: &kube::Error) -> bool {
+    matches!(error, kube::Error::Api(response) if response.code == 404)
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,3 +3,4 @@ mod cleanup_test;
 mod job_state_test;
 mod reconcile_backup_test;
 mod restore_test;
+mod strimzi_api_test;

--- a/tests/integration/strimzi_api_test.rs
+++ b/tests/integration/strimzi_api_test.rs
@@ -1,0 +1,270 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use http::{Request, Response};
+use http_body_util::BodyExt;
+use kafka_backup_operator::crd::common::{
+    AuthenticationSpec, AuthenticationType, KafkaUserRef, StrimziClusterRef,
+};
+use kafka_backup_operator::strimzi::kafka_cr::resolve_kafka_cluster;
+use kafka_backup_operator::strimzi::kafka_user::{resolve_auth, ResolvedAuth};
+use kube::{client::Body, Client};
+use serde_json::{json, Value};
+use tokio::task::JoinHandle;
+use tower_test::mock;
+
+const KAFKA_V1_PATH: &str = "/apis/kafka.strimzi.io/v1/namespaces/kafka/kafkas/my-cluster";
+const KAFKA_V1BETA2_PATH: &str =
+    "/apis/kafka.strimzi.io/v1beta2/namespaces/kafka/kafkas/my-cluster";
+const KAFKA_USER_V1_PATH: &str =
+    "/apis/kafka.strimzi.io/v1/namespaces/kafka/kafkausers/backup-user";
+const KAFKA_USER_V1BETA2_PATH: &str =
+    "/apis/kafka.strimzi.io/v1beta2/namespaces/kafka/kafkausers/backup-user";
+
+struct MockApi {
+    client: Client,
+    requests: Arc<Mutex<Vec<String>>>,
+    dispatcher: JoinHandle<()>,
+}
+
+impl MockApi {
+    fn new(responses: impl IntoIterator<Item = (&'static str, u16, Value)>) -> Self {
+        let responses: HashMap<String, (u16, Value)> = responses
+            .into_iter()
+            .map(|(path, status, body)| (path.to_string(), (status, body)))
+            .collect();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&requests);
+        let (mock_service, mut handle) = mock::pair::<Request<Body>, Response<Body>>();
+
+        let dispatcher = tokio::spawn(async move {
+            while let Some((request, send)) = handle.next_request().await {
+                let path = request.uri().path().to_string();
+                request.into_body().collect().await.unwrap();
+                recorded.lock().unwrap().push(path.clone());
+
+                let (status, body) = responses
+                    .get(&path)
+                    .cloned()
+                    .unwrap_or_else(|| (404, not_found(&path)));
+                let response = Response::builder()
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap();
+                send.send_response(response);
+            }
+        });
+
+        Self {
+            client: Client::new(mock_service, "kafka"),
+            requests,
+            dispatcher,
+        }
+    }
+
+    async fn finish(self) -> Vec<String> {
+        drop(self.client);
+        self.dispatcher.await.unwrap();
+        Arc::try_unwrap(self.requests)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+    }
+}
+
+fn not_found(path: &str) -> Value {
+    json!({
+        "kind": "Status",
+        "apiVersion": "v1",
+        "metadata": {},
+        "status": "Failure",
+        "message": format!("resource at {path} not found"),
+        "reason": "NotFound",
+        "code": 404
+    })
+}
+
+fn forbidden(path: &str) -> Value {
+    json!({
+        "kind": "Status",
+        "apiVersion": "v1",
+        "metadata": {},
+        "status": "Failure",
+        "message": format!("access to {path} is forbidden"),
+        "reason": "Forbidden",
+        "code": 403
+    })
+}
+
+fn kafka(api_version: &str) -> Value {
+    json!({
+        "apiVersion": api_version,
+        "kind": "Kafka",
+        "metadata": {"name": "my-cluster", "namespace": "kafka"},
+        "spec": {"kafka": {"listeners": [
+            {"name": "plain", "port": 9092, "type": "internal", "tls": false}
+        ]}},
+        "status": {"listeners": [
+            {"name": "plain", "bootstrapServers": "my-cluster-kafka-bootstrap.kafka.svc:9092"}
+        ]}
+    })
+}
+
+fn kafka_user(api_version: &str) -> Value {
+    json!({
+        "apiVersion": api_version,
+        "kind": "KafkaUser",
+        "metadata": {"name": "backup-user", "namespace": "kafka"},
+        "status": {"secret": "backup-user-credentials"}
+    })
+}
+
+fn cluster_ref() -> StrimziClusterRef {
+    StrimziClusterRef {
+        name: "my-cluster".to_string(),
+        namespace: None,
+        ca_secret: None,
+        listener: None,
+    }
+}
+
+fn scram_auth() -> AuthenticationSpec {
+    AuthenticationSpec {
+        auth_type: AuthenticationType::ScramSha512,
+        kafka_user_ref: Some(KafkaUserRef {
+            name: "backup-user".to_string(),
+        }),
+        certificate_and_key: None,
+        password_secret: None,
+        username: None,
+    }
+}
+
+#[tokio::test]
+async fn resolves_kafka_from_strimzi_v1() {
+    let api = MockApi::new([(KAFKA_V1_PATH, 200, kafka("kafka.strimzi.io/v1"))]);
+
+    let cluster = resolve_kafka_cluster(&api.client, &cluster_ref(), "kafka", None)
+        .await
+        .expect("Strimzi 1.0 serves Kafka only at v1");
+
+    assert_eq!(cluster.name, "my-cluster");
+    assert_eq!(
+        cluster.bootstrap_servers,
+        "my-cluster-kafka-bootstrap.kafka.svc:9092"
+    );
+    assert_eq!(api.finish().await, [KAFKA_V1_PATH]);
+}
+
+#[tokio::test]
+async fn falls_back_to_v1beta2_for_older_strimzi_kafka() {
+    let api = MockApi::new([
+        (KAFKA_V1_PATH, 404, not_found(KAFKA_V1_PATH)),
+        (KAFKA_V1BETA2_PATH, 200, kafka("kafka.strimzi.io/v1beta2")),
+    ]);
+
+    resolve_kafka_cluster(&api.client, &cluster_ref(), "kafka", None)
+        .await
+        .expect("pre-0.49 Strimzi Kafka resources must remain supported");
+
+    assert_eq!(api.finish().await, [KAFKA_V1_PATH, KAFKA_V1BETA2_PATH]);
+}
+
+#[tokio::test]
+async fn kafka_missing_from_both_versions_keeps_domain_error() {
+    let api = MockApi::new([
+        (KAFKA_V1_PATH, 404, not_found(KAFKA_V1_PATH)),
+        (KAFKA_V1BETA2_PATH, 404, not_found(KAFKA_V1BETA2_PATH)),
+    ]);
+
+    let error = resolve_kafka_cluster(&api.client, &cluster_ref(), "kafka", None)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.reason(), "StrimziClusterNotFound");
+    assert_eq!(api.finish().await, [KAFKA_V1_PATH, KAFKA_V1BETA2_PATH]);
+}
+
+#[tokio::test]
+async fn kafka_authorization_error_is_not_masked_by_fallback() {
+    let api = MockApi::new([
+        (KAFKA_V1_PATH, 403, forbidden(KAFKA_V1_PATH)),
+        (KAFKA_V1BETA2_PATH, 200, kafka("kafka.strimzi.io/v1beta2")),
+    ]);
+
+    let error = resolve_kafka_cluster(&api.client, &cluster_ref(), "kafka", None)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.reason(), "KubernetesError");
+    assert_eq!(api.finish().await, [KAFKA_V1_PATH]);
+}
+
+#[tokio::test]
+async fn resolves_kafka_user_from_strimzi_v1() {
+    let api = MockApi::new([(KAFKA_USER_V1_PATH, 200, kafka_user("kafka.strimzi.io/v1"))]);
+
+    let auth = resolve_auth(&api.client, Some(&scram_auth()), "kafka")
+        .await
+        .expect("Strimzi 1.0 serves KafkaUser only at v1");
+
+    match auth {
+        ResolvedAuth::ScramSha512 {
+            username,
+            secret_name,
+            password_key,
+        } => {
+            assert_eq!(username, "backup-user");
+            assert_eq!(secret_name, "backup-user-credentials");
+            assert_eq!(password_key, "password");
+        }
+        other => panic!("expected SCRAM authentication, got {other:?}"),
+    }
+    assert_eq!(api.finish().await, [KAFKA_USER_V1_PATH]);
+}
+
+#[tokio::test]
+async fn falls_back_to_v1beta2_for_older_strimzi_kafka_user() {
+    let api = MockApi::new([
+        (KAFKA_USER_V1_PATH, 404, not_found(KAFKA_USER_V1_PATH)),
+        (
+            KAFKA_USER_V1BETA2_PATH,
+            200,
+            kafka_user("kafka.strimzi.io/v1beta2"),
+        ),
+    ]);
+
+    resolve_auth(&api.client, Some(&scram_auth()), "kafka")
+        .await
+        .expect("pre-0.49 Strimzi KafkaUser resources must remain supported");
+
+    assert_eq!(
+        api.finish().await,
+        [KAFKA_USER_V1_PATH, KAFKA_USER_V1BETA2_PATH]
+    );
+}
+
+#[tokio::test]
+async fn kafka_user_missing_from_both_versions_keeps_domain_error() {
+    let api = MockApi::new([
+        (KAFKA_USER_V1_PATH, 404, not_found(KAFKA_USER_V1_PATH)),
+        (
+            KAFKA_USER_V1BETA2_PATH,
+            404,
+            not_found(KAFKA_USER_V1BETA2_PATH),
+        ),
+    ]);
+
+    let error = resolve_auth(&api.client, Some(&scram_auth()), "kafka")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.reason(), "KafkaUserNotFound");
+    assert_eq!(
+        api.finish().await,
+        [KAFKA_USER_V1_PATH, KAFKA_USER_V1BETA2_PATH]
+    );
+}


### PR DESCRIPTION
Fixes #39

## Problem

Strimzi 1.0.0 removed the legacy CRD API versions and serves `Kafka` and `KafkaUser` only through `kafka.strimzi.io/v1`. The operator hardcoded both lookups to `v1beta2`, so Kubernetes returned 404 and reconciliation incorrectly surfaced `StrimziClusterNotFound` even though the Kafka resource existed.

The failure reproduces with the Strimzi 1.0 CRDs: the v1 resource is present, the v1beta2 endpoint itself is absent, and v0.2.12 cannot resolve the cluster.

## Fix

- Add one shared Strimzi resource lookup that requests stable `v1` first.
- Retry `v1beta2` only after a 404, preserving compatibility with Strimzi releases before 0.49.
- Apply the same lookup policy to both `Kafka` and referenced `KafkaUser` resources.
- Return authorization, transport, and other non-404 errors directly rather than masking them with a fallback.
- Preserve the existing domain errors when the resource is missing from both versions.
- Document v1 and legacy v1beta2 support and prepare release 0.2.13.

RBAC is unchanged because Kubernetes permissions target the API group and resource, not an individual served version. The listener and KafkaUser status fields consumed by this operator have the same shape in the Strimzi v1 schema.

## Backward compatibility

- Strimzi 1.0+: v1 succeeds directly.
- Strimzi 0.49-0.51: v1 is preferred while both versions are served.
- Strimzi 0.48 and earlier v1beta2 installations: the v1 404 triggers the legacy lookup.
- Missing resources still produce `StrimziClusterNotFound` or `KafkaUserNotFound`.
- A v1 authorization failure does not fall back and remains a Kubernetes error.

## Testing

- Added 7 mock Kubernetes API integration tests covering v1 Kafka/KafkaUser resolution, v1beta2 fallback for both resource kinds, missing-resource error preservation, and non-404 error behavior. The v1-only tests fail against v0.2.12 and pass with this fix.
- `cargo fmt --all -- --check`
- `cargo test --all-features` — 46 unit and 45 integration tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets`
- CRD regeneration and checked-in/Helm CRD comparison
- `helm lint` and default `helm template`
- `scripts/release-gate.sh` for 0.2.13
- Final Docker image build and dynamic-linking/executable smoke tests

### End-to-end Kubernetes validation

Deployed the fixed image through the Helm chart into disposable kind clusters using the upstream Strimzi CRDs:

1. **Strimzi 1.0.0, v1 only:** verified that `/apis/kafka.strimzi.io/v1beta2` is absent. A suspended `KafkaBackup` referencing a v1 `Kafka` and v1 `KafkaUser` reconciled to `Ready/BackupSuspended`, generated the expected SCRAM ConfigMap and credential wiring, and created its suspended CronJob. No legacy fallback was attempted.
2. **Strimzi 0.48.0, v1beta2 only:** verified the v1-to-v1beta2 fallback for both `Kafka` and `KafkaUser`. The same backup reconciled successfully and generated the same ConfigMap, credential wiring, CronJob, and status.

The repository non-blocking `cargo audit` job continues to report existing transitive advisories from the current main lockfile; this PR changes no dependency versions.