### PR TITLE
fix: reconcile KafkaBackup resources into scheduled CronJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.14 - 2026-07-11
+
+### Fixed
+
+- Force server-side apply for operator-owned scheduled backup CronJobs so `KafkaBackup` changes such as `spec.resources` converge even when another field manager previously claimed parts of the generated pod template. This prevents apply conflicts from leaving the CronJob stale until it is deleted and the backup is reconciled again. Fixes [#41](https://github.com/osodevops/strimzi-backup-operator/issues/41).
+
 ## 0.2.13 - 2026-07-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.13
-appVersion: "0.2.13"
+version: 0.2.14
+appVersion: "0.2.14"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/src/reconcilers/backup.rs
+++ b/src/reconcilers/backup.rs
@@ -646,7 +646,11 @@ async fn apply_resource<
     let patch = serde_json::to_value(resource).map_err(Error::Serialization)?;
     api.patch(
         name,
-        &PatchParams::apply("kafka-backup-operator"),
+        // This resource is fully generated and owned by the KafkaBackup. A
+        // mutating policy or manual edit may otherwise take ownership of pod
+        // template fields and make every later reconciliation fail with a
+        // server-side apply conflict until the resource is deleted.
+        &PatchParams::apply("kafka-backup-operator").force(),
         &Patch::Apply(patch),
     )
     .await?;

--- a/tests/integration/reconcile_backup_test.rs
+++ b/tests/integration/reconcile_backup_test.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
 
 use http::{Request, Response};
 use http_body_util::BodyExt;
@@ -16,6 +19,7 @@ use tower_test::mock;
 struct RecordedRequest {
     method: String,
     path: String,
+    query: Option<String>,
     body: serde_json::Value,
 }
 
@@ -77,6 +81,7 @@ async fn reconcile_with_mock_api(backup: KafkaBackup) -> Vec<RecordedRequest> {
             while let Some((request, send)) = handle.next_request().await {
                 let method = request.method().to_string();
                 let path = request.uri().path().to_string();
+                let query = request.uri().query().map(str::to_string);
                 let bytes = request.into_body().collect().await.unwrap().to_bytes();
                 let body: serde_json::Value = if bytes.is_empty() {
                     serde_json::Value::Null
@@ -117,10 +122,12 @@ async fn reconcile_with_mock_api(backup: KafkaBackup) -> Vec<RecordedRequest> {
                     (200, body.clone())
                 };
 
-                recorded
-                    .lock()
-                    .unwrap()
-                    .push(RecordedRequest { method, path, body });
+                recorded.lock().unwrap().push(RecordedRequest {
+                    method,
+                    path,
+                    query,
+                    body,
+                });
 
                 let response = Response::builder()
                     .status(status)
@@ -187,5 +194,37 @@ async fn test_reconcile_applies_active_cronjob_when_not_suspended() {
     assert_eq!(
         status_patch.body["status"]["conditions"][0]["reason"],
         json!("BackupScheduled")
+    );
+}
+
+#[tokio::test]
+async fn test_reconcile_force_applies_resource_updates_to_owned_cronjob() {
+    let mut backup = scheduled_backup(false);
+    backup.spec.resources = Some(ResourceRequirementsSpec {
+        requests: BTreeMap::from([
+            ("cpu".to_string(), "250m".to_string()),
+            ("memory".to_string(), "256Mi".to_string()),
+        ]),
+        limits: BTreeMap::from([
+            ("cpu".to_string(), "1".to_string()),
+            ("memory".to_string(), "1Gi".to_string()),
+        ]),
+    });
+
+    let requests = reconcile_with_mock_api(backup).await;
+    let cronjob_patch = find_cronjob_patch(&requests);
+    let resources = &cronjob_patch.body["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        ["containers"][0]["resources"];
+
+    assert_eq!(resources["requests"]["cpu"], json!("250m"));
+    assert_eq!(resources["requests"]["memory"], json!("256Mi"));
+    assert_eq!(resources["limits"]["cpu"], json!("1"));
+    assert_eq!(resources["limits"]["memory"], json!("1Gi"));
+    assert!(
+        cronjob_patch
+            .query
+            .as_deref()
+            .is_some_and(|query| query.split('&').any(|part| part == "force=true")),
+        "controller-owned CronJob fields must be force-applied so a stale field manager cannot block spec updates"
     );
 }


### PR DESCRIPTION
## Summary

- force server-side apply for the fully generated, operator-owned backup CronJob so stale field ownership cannot block `KafkaBackup` spec changes
- add a reconciler regression test covering `spec.resources` propagation and the forced apply request
- prepare the required `0.2.14` changelog and release metadata

## Triage

A clean CronJob updates correctly on current `main`. The reported stale state is reproducible when another field manager has claimed the generated container resource fields: changing `KafkaBackup.spec.resources` then returns four HTTP 409 apply conflicts, leaves `status.observedGeneration` behind, and keeps the old CronJob values. Deleting the CronJob clears that ownership, which explains the reported workaround.

Because the CronJob is generated in full and owned by the `KafkaBackup`, reconciliation now force-applies its desired fields. In the same Kind scenario, the fixed operator takes ownership, updates all resource requests and limits, and advances the observed generation without deleting the CronJob.

## Verification

- `bash scripts/release-gate.sh`
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test --all-features` (92 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- CRD regeneration and checked-in CRD parity
- `helm lint` and default chart render
- release container build plus linkage/executable smoke test
- end-to-end reproduction and recovery on a disposable Kubernetes 1.36 Kind cluster

Fixes #41
