### PR TITLE
fix: honor pause reconciliation annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.15 - 2026-07-19
+
+### Fixed
+
+- Honor `strimzi.io/pause-reconciliation: "true"` on `KafkaBackup` and `KafkaRestore` resources. Paused resources now receive a `ReconciliationPaused` status condition without creating or updating finalizers, ConfigMaps, Jobs, or CronJobs; deletion cleanup remains available for resources that were paused after reconciliation. Fixes [#44](https://github.com/osodevops/strimzi-backup-operator/issues/44).
+
 ## 0.2.14 - 2026-07-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ spec:
 | `KafkaBackup` | `kb` | `kafkabackup.com/v1alpha1` | Defines a backup configuration with scheduling, retention, and storage |
 | `KafkaRestore` | `kr` | `kafkabackup.com/v1alpha1` | Defines a restore operation with PITR, topic mapping, and consumer group restore |
 
+### Pausing reconciliation
+
+`KafkaBackup` and `KafkaRestore` support Strimzi's standard pause annotation.
+While its value is `"true"`, the operator reports a `ReconciliationPaused`
+condition but does not add a finalizer, resolve dependencies, or create/update
+ConfigMaps, Jobs, or CronJobs. Removing the annotation or setting it to
+`"false"` resumes normal reconciliation.
+
+```bash
+kubectl annotate kafkabackup restore-source strimzi.io/pause-reconciliation="true"
+kubectl annotate kafkabackup restore-source strimzi.io/pause-reconciliation-
+```
+
 ## Storage Configuration
 
 ### Amazon S3

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.14
-appVersion: "0.2.14"
+version: 0.2.15
+appVersion: "0.2.15"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/src/reconcilers/backup.rs
+++ b/src/reconcilers/backup.rs
@@ -19,8 +19,8 @@ use crate::jobs::cronjob::build_backup_cronjob;
 use crate::jobs::job_state::{classify_jobs, job_failed, job_succeeded, should_create_backup_job};
 use crate::metrics::prometheus::MetricsState;
 use crate::reconcilers::{
-    cleanup_delete_params, job_service_account_name, FINALIZER, TRIGGER_ANNOTATION,
-    TRIGGER_VALUE_NOW,
+    cleanup_delete_params, is_reconciliation_paused, job_service_account_name, FINALIZER,
+    TRIGGER_ANNOTATION, TRIGGER_VALUE_NOW,
 };
 use crate::retention::policy::evaluate_retention;
 use crate::retention::storage::{discover_backup_history, prune_backup_ids};
@@ -43,6 +43,16 @@ pub async fn reconcile_backup(
     // Check if being deleted
     if backup.metadata.deletion_timestamp.is_some() {
         return handle_cleanup(&backup, &client, &namespace).await;
+    }
+
+    // Match Strimzi's pause semantics: a newly created paused resource is
+    // status-only and must not gain a finalizer, ConfigMap, Job, or CronJob.
+    // Deletion is intentionally handled first so an existing finalizer cannot
+    // strand a resource that is deleted while paused.
+    if is_reconciliation_paused(backup.as_ref()) {
+        update_status_reconciliation_paused(&backup_api, &backup).await?;
+        info!(%name, "Reconciliation paused by annotation");
+        return Ok(());
     }
 
     // Ensure finalizer is set
@@ -482,6 +492,25 @@ async fn update_status_running(api: &Api<KafkaBackup>, name: &str, generation: i
     status.conditions = vec![not_ready(REASON_BACKUP_RUNNING, "Backup job is running")];
     status.observed_generation = Some(generation);
     patch_status(api, name, &status).await
+}
+
+async fn update_status_reconciliation_paused(
+    api: &Api<KafkaBackup>,
+    backup: &KafkaBackup,
+) -> Result<()> {
+    let name = backup.name_any();
+    let generation = backup.metadata.generation.unwrap_or(0);
+    let mut status = backup.status.clone().unwrap_or_default();
+    let already_current =
+        is_condition_true(&status.conditions, CONDITION_TYPE_RECONCILIATION_PAUSED)
+            && status.observed_generation == Some(generation);
+    if already_current {
+        return Ok(());
+    }
+
+    status.conditions = vec![reconciliation_paused()];
+    status.observed_generation = Some(generation);
+    patch_status(api, &name, &status).await
 }
 
 async fn update_status_scheduled(

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -8,6 +8,17 @@ pub const FINALIZER: &str = "kafkabackup.com/cleanup";
 pub const TRIGGER_ANNOTATION: &str = "kafkabackup.com/trigger";
 pub const TRIGGER_VALUE_NOW: &str = "now";
 
+/// Strimzi-compatible annotation for temporarily suppressing reconciliation.
+pub const PAUSE_RECONCILIATION_ANNOTATION: &str = "strimzi.io/pause-reconciliation";
+
+/// Return whether a custom resource has explicitly paused reconciliation.
+pub fn is_reconciliation_paused<K: kube::ResourceExt>(resource: &K) -> bool {
+    resource
+        .annotations()
+        .get(PAUSE_RECONCILIATION_ANNOTATION)
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.

--- a/src/reconcilers/restore.rs
+++ b/src/reconcilers/restore.rs
@@ -16,7 +16,9 @@ use crate::error::{Error, Result};
 use crate::jobs::job_state::{classify_jobs, JobsState};
 use crate::jobs::restore_job::build_restore_job;
 use crate::metrics::prometheus::MetricsState;
-use crate::reconcilers::{cleanup_delete_params, job_service_account_name, FINALIZER};
+use crate::reconcilers::{
+    cleanup_delete_params, is_reconciliation_paused, job_service_account_name, FINALIZER,
+};
 use crate::status::conditions::*;
 use crate::strimzi::kafka_cr::resolve_kafka_cluster;
 use crate::strimzi::kafka_user::resolve_auth;
@@ -36,6 +38,14 @@ pub async fn reconcile_restore(
     // Check if being deleted
     if restore.metadata.deletion_timestamp.is_some() {
         return handle_cleanup(&restore, &client, &namespace).await;
+    }
+
+    // Keep deletion cleanup available while paused, but otherwise perform no
+    // resource mutations beyond reporting the Strimzi-compatible condition.
+    if is_reconciliation_paused(restore.as_ref()) {
+        update_status_reconciliation_paused(&restore_api, &restore).await?;
+        info!(%name, "Reconciliation paused by annotation");
+        return Ok(());
     }
 
     // Ensure finalizer
@@ -336,6 +346,25 @@ async fn update_status_running(api: &Api<KafkaRestore>, name: &str, generation: 
         ..Default::default()
     };
     patch_status(api, name, &status).await
+}
+
+async fn update_status_reconciliation_paused(
+    api: &Api<KafkaRestore>,
+    restore: &KafkaRestore,
+) -> Result<()> {
+    let name = restore.name_any();
+    let generation = restore.metadata.generation.unwrap_or(0);
+    let mut status = restore.status.clone().unwrap_or_default();
+    let already_current =
+        is_condition_true(&status.conditions, CONDITION_TYPE_RECONCILIATION_PAUSED)
+            && status.observed_generation == Some(generation);
+    if already_current {
+        return Ok(());
+    }
+
+    status.conditions = vec![reconciliation_paused()];
+    status.observed_generation = Some(generation);
+    patch_status(api, &name, &status).await
 }
 
 async fn update_status_completed(

--- a/src/status/conditions.rs
+++ b/src/status/conditions.rs
@@ -8,6 +8,7 @@ pub const CONDITION_TYPE_BACKUP_COMPLETE: &str = "BackupComplete";
 pub const CONDITION_TYPE_RESTORE_COMPLETE: &str = "RestoreComplete";
 pub const CONDITION_TYPE_SCHEDULED: &str = "Scheduled";
 pub const CONDITION_TYPE_ERROR: &str = "Error";
+pub const CONDITION_TYPE_RECONCILIATION_PAUSED: &str = "ReconciliationPaused";
 
 /// Condition status values
 pub const STATUS_TRUE: &str = "True";
@@ -27,6 +28,7 @@ pub const REASON_RESTORE_FAILED: &str = "RestoreFailed";
 pub const REASON_CLUSTER_NOT_FOUND: &str = "ClusterNotFound";
 pub const REASON_INVALID_CONFIG: &str = "InvalidConfiguration";
 pub const REASON_SECRET_NOT_FOUND: &str = "SecretNotFound";
+pub const REASON_RECONCILIATION_PAUSED: &str = "ReconciliationPaused";
 
 /// Create a new condition
 pub fn new_condition(condition_type: &str, status: &str, reason: &str, message: &str) -> Condition {
@@ -81,6 +83,16 @@ pub fn ready(reason: &str, message: &str) -> Condition {
 /// Create a Ready=False condition
 pub fn not_ready(reason: &str, message: &str) -> Condition {
     new_condition(CONDITION_TYPE_READY, STATUS_FALSE, reason, message)
+}
+
+/// Create the condition used while the Strimzi pause annotation is enabled.
+pub fn reconciliation_paused() -> Condition {
+    new_condition(
+        CONDITION_TYPE_RECONCILIATION_PAUSED,
+        STATUS_TRUE,
+        REASON_RECONCILIATION_PAUSED,
+        "Reconciliation is paused by annotation",
+    )
 }
 
 /// Create an error condition (sets Ready=False and adds Error condition)

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,5 +2,6 @@ mod backup_test;
 mod cleanup_test;
 mod job_state_test;
 mod reconcile_backup_test;
+mod reconcile_pause_test;
 mod restore_test;
 mod strimzi_api_test;

--- a/tests/integration/reconcile_pause_test.rs
+++ b/tests/integration/reconcile_pause_test.rs
@@ -1,0 +1,192 @@
+use std::sync::{Arc, Mutex};
+
+use http::{Request, Response};
+use http_body_util::BodyExt;
+use kafka_backup_operator::crd::common::{
+    FilesystemStorageSpec, StorageSpec, StorageType, StrimziClusterRef,
+};
+use kafka_backup_operator::crd::kafka_backup::KafkaBackupSpec;
+use kafka_backup_operator::crd::kafka_restore::{BackupRef, KafkaRestoreSpec};
+use kafka_backup_operator::crd::{KafkaBackup, KafkaRestore};
+use kafka_backup_operator::metrics::prometheus::MetricsState;
+use kafka_backup_operator::reconcilers::backup::reconcile_backup;
+use kafka_backup_operator::reconcilers::restore::reconcile_restore;
+use kube::client::Body;
+use kube::Client;
+use serde::Serialize;
+use serde_json::json;
+use tower_test::mock;
+
+#[derive(Debug)]
+struct RecordedRequest {
+    method: String,
+    path: String,
+    body: serde_json::Value,
+}
+
+fn cluster_ref() -> StrimziClusterRef {
+    StrimziClusterRef {
+        name: "missing-after-disaster".to_string(),
+        namespace: None,
+        ca_secret: None,
+        listener: None,
+    }
+}
+
+fn paused_backup() -> KafkaBackup {
+    let spec = KafkaBackupSpec {
+        strimzi_cluster_ref: cluster_ref(),
+        authentication: None,
+        topics: None,
+        connection: None,
+        consumer_groups: None,
+        logging: None,
+        env: Vec::new(),
+        storage: StorageSpec {
+            storage_type: StorageType::Filesystem,
+            s3: None,
+            azure: None,
+            gcs: None,
+            filesystem: Some(FilesystemStorageSpec {
+                path: "/backups".to_string(),
+            }),
+        },
+        backup: None,
+        metrics: None,
+        offset_storage: None,
+        schedule: None,
+        retention: None,
+        resources: None,
+        template: None,
+        image: None,
+        backoff_limit: None,
+    };
+    let mut backup = KafkaBackup::new("restore-source", spec);
+    backup.metadata.namespace = Some("kafka".to_string());
+    backup.metadata.uid = Some("backup-uid".to_string());
+    backup.metadata.generation = Some(1);
+    backup.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        "strimzi.io/pause-reconciliation".to_string(),
+        "true".to_string(),
+    )]));
+    backup
+}
+
+fn paused_restore() -> KafkaRestore {
+    let spec = KafkaRestoreSpec {
+        strimzi_cluster_ref: cluster_ref(),
+        authentication: None,
+        backup_ref: BackupRef {
+            name: "restore-source".to_string(),
+            backup_id: Some("snapshot-before-disaster".to_string()),
+        },
+        topics: None,
+        point_in_time: None,
+        connection: None,
+        logging: None,
+        env: Vec::new(),
+        topic_mapping: Vec::new(),
+        consumer_groups: None,
+        restore: None,
+        metrics: None,
+        resources: None,
+        template: None,
+        image: None,
+        backoff_limit: None,
+    };
+    let mut restore = KafkaRestore::new("disaster-restore", spec);
+    restore.metadata.namespace = Some("kafka".to_string());
+    restore.metadata.uid = Some("restore-uid".to_string());
+    restore.metadata.generation = Some(1);
+    restore.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        "strimzi.io/pause-reconciliation".to_string(),
+        "TRUE".to_string(),
+    )]));
+    restore
+}
+
+async fn reconcile_paused_resource<K, F, Fut>(resource: K, reconcile: F) -> Vec<RecordedRequest>
+where
+    K: Serialize,
+    F: FnOnce(Client, MetricsState) -> Fut,
+    Fut: std::future::Future<Output = kafka_backup_operator::error::Result<()>>,
+{
+    let (mock_service, mut handle) = mock::pair::<Request<Body>, Response<Body>>();
+    let recorded = Arc::new(Mutex::new(Vec::new()));
+    let resource_json = serde_json::to_value(resource).unwrap();
+
+    let dispatcher = {
+        let recorded = Arc::clone(&recorded);
+        tokio::spawn(async move {
+            while let Some((request, send)) = handle.next_request().await {
+                let method = request.method().to_string();
+                let path = request.uri().path().to_string();
+                let bytes = request.into_body().collect().await.unwrap().to_bytes();
+                let body = if bytes.is_empty() {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::from_slice(&bytes).unwrap()
+                };
+
+                recorded
+                    .lock()
+                    .unwrap()
+                    .push(RecordedRequest { method, path, body });
+
+                let response = Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&resource_json).unwrap()))
+                    .unwrap();
+                send.send_response(response);
+            }
+        })
+    };
+
+    let client = Client::new(mock_service, "kafka");
+    reconcile(client, MetricsState::new())
+        .await
+        .expect("paused reconciliation should succeed");
+    dispatcher.await.unwrap();
+    Arc::try_unwrap(recorded).unwrap().into_inner().unwrap()
+}
+
+fn assert_status_only(requests: &[RecordedRequest], resource_plural: &str, name: &str) {
+    assert_eq!(requests.len(), 1, "a paused resource must be status-only");
+    let request = &requests[0];
+    assert_eq!(request.method, "PATCH");
+    assert!(request
+        .path
+        .ends_with(&format!("/{resource_plural}/{name}/status")));
+    assert_eq!(
+        request.body["status"]["conditions"][0]["type"],
+        json!("ReconciliationPaused")
+    );
+    assert_eq!(
+        request.body["status"]["conditions"][0]["status"],
+        json!("True")
+    );
+    assert_eq!(request.body["status"]["observedGeneration"], json!(1));
+}
+
+#[tokio::test]
+async fn paused_backup_does_not_create_operator_resources() {
+    let backup = paused_backup();
+    let requests = reconcile_paused_resource(backup.clone(), move |client, metrics| async move {
+        reconcile_backup(Arc::new(backup), client, &metrics).await
+    })
+    .await;
+
+    assert_status_only(&requests, "kafkabackups", "restore-source");
+}
+
+#[tokio::test]
+async fn paused_restore_does_not_resolve_dependencies_or_create_a_job() {
+    let restore = paused_restore();
+    let requests = reconcile_paused_resource(restore.clone(), move |client, metrics| async move {
+        reconcile_restore(Arc::new(restore), client, &metrics).await
+    })
+    .await;
+
+    assert_status_only(&requests, "kafkarestores", "disaster-restore");
+}


### PR DESCRIPTION
## Summary

- honor `strimzi.io/pause-reconciliation: "true"` for both `KafkaBackup` and `KafkaRestore`
- report the Strimzi-compatible `ReconciliationPaused=True` condition while avoiding finalizers, dependency resolution, ConfigMaps, Jobs, and CronJobs
- keep deletion cleanup ahead of the pause guard so previously reconciled resources cannot become stuck
- document pause/resume behavior and prepare release `0.2.15`

## Triage

This is a confirmed operator bug. Neither reconciler inspected the Strimzi pause annotation, so a newly created paused `KafkaBackup` continued through finalizer, cluster resolution, ConfigMap, and Job/CronJob creation. The guard now runs immediately after deletion handling and before any other mutation.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-features` (94 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- CRD regeneration and checked-in CRD parity
- `helm lint` and default chart render
- `bash scripts/release-gate.sh`
- production container build plus linkage/executable smoke tests
- Kubernetes 1.36 Kind test on Docker: installed the chart, created paused backup/restore CRs referencing a deliberately missing Strimzi cluster, observed `ReconciliationPaused=True`, no finalizers, and zero operator-owned ConfigMaps/Jobs/CronJobs

Fixes #44