### PR TITLE
fix: expose and discover backup job metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add an opt-in Helm `metrics.jobPodMonitor` that discovers metrics-enabled `kafka-backup` Job and CronJob pods directly across namespaces. Generated backup and restore containers now declare their configured metrics port and carry a dedicated discovery label. Fixes [#43](https://github.com/osodevops/strimzi-backup-operator/issues/43).
+- Add `spec.metrics.keepAliveSeconds` for backup and restore jobs so one-shot
+  operations remain scrapeable after completion, and update the default job
+  image to the released `osodevops/kafka-backup:v0.15.10` that supports it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ All notable changes to this project will be documented in this file.
 - Add an opt-in Helm `metrics.jobPodMonitor` that discovers metrics-enabled `kafka-backup` Job and CronJob pods directly across namespaces. Generated backup and restore containers now declare their configured metrics port and carry a dedicated discovery label. Fixes [#43](https://github.com/osodevops/strimzi-backup-operator/issues/43).
 - Add `spec.metrics.keepAliveSeconds` for backup and restore jobs so one-shot
   operations remain scrapeable after completion, and update the default job
-  image to the released `osodevops/kafka-backup:v0.15.10` that supports it.
+  image to the released `osodevops/kafka-backup:v0.15.11` that supports it.
+- Consume the runtime cardinality fix and progress metrics from
+  `kafka-backup:v0.15.11`: aggregate continuous lag, snapshot target/remaining,
+  and explicit unlimited partition series with `maxPartitionLabels: 0`. Fixes
+  [#45](https://github.com/osodevops/strimzi-backup-operator/issues/45).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.15 - 2026-07-19
+
+### Fixed
+
+- Honor `strimzi.io/pause-reconciliation: "true"` on `KafkaBackup` and `KafkaRestore` resources. Paused resources now receive a `ReconciliationPaused` status condition without creating or updating finalizers, ConfigMaps, Jobs, or CronJobs; deletion cleanup remains available for resources that were paused after reconciliation. Fixes [#44](https://github.com/osodevops/strimzi-backup-operator/issues/44).
+
 ## 0.2.14 - 2026-07-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.16 - 2026-07-19
+
+### Added
+
+- Add an opt-in Helm `metrics.jobPodMonitor` that discovers metrics-enabled `kafka-backup` Job and CronJob pods directly across namespaces. Generated backup and restore containers now declare their configured metrics port and carry a dedicated discovery label. Fixes [#43](https://github.com/osodevops/strimzi-backup-operator/issues/43).
+
+### Fixed
+
+- Always expose `strimzi_backup_operator_build_info` from the operator's `/metrics` endpoint and record reconciliation counts and durations, so a healthy idle operator no longer returns an empty `200` response. Monitoring documentation now distinguishes the operator `ServiceMonitor` on port 9090 from job metrics on port 8080.
+
 ## 0.2.15 - 2026-07-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ spec:
 | `KafkaBackup` | `kb` | `kafkabackup.com/v1alpha1` | Defines a backup configuration with scheduling, retention, and storage |
 | `KafkaRestore` | `kr` | `kafkabackup.com/v1alpha1` | Defines a restore operation with PITR, topic mapping, and consumer group restore |
 
+### Pausing reconciliation
+
+`KafkaBackup` and `KafkaRestore` support Strimzi's standard pause annotation.
+While its value is `"true"`, the operator reports a `ReconciliationPaused`
+condition but does not add a finalizer, resolve dependencies, or create/update
+ConfigMaps, Jobs, or CronJobs. Removing the annotation or setting it to
+`"false"` resumes normal reconciliation.
+
+```bash
+kubectl annotate kafkabackup restore-source strimzi.io/pause-reconciliation="true"
+kubectl annotate kafkabackup restore-source strimzi.io/pause-reconciliation-
+```
+
 ## Storage Configuration
 
 ### Amazon S3

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ spec:
 | `azureWorkloadIdentity.clientId` | Azure Managed Identity client ID | `""` |
 | `metrics.enabled` | Enable Prometheus metrics | `true` |
 | `metrics.serviceMonitor.enabled` | Create a Prometheus ServiceMonitor | `false` |
+| `metrics.jobPodMonitor.enabled` | Create a PodMonitor for backup/restore job metrics | `false` |
 | `leaderElection.enabled` | Enable leader election for HA | `false` |
 | `resources.requests.cpu` | CPU request | `100m` |
 | `resources.requests.memory` | Memory request | `128Mi` |
@@ -401,20 +402,27 @@ spec:
 
 ## Monitoring
 
-The operator exposes Prometheus metrics on port `9090` at `/metrics`:
+There are two independent metrics endpoints:
+
+- The operator exposes controller health metrics on port `9090` at `/metrics`.
+- Each `kafka-backup` backup/restore pod exposes operation and progress metrics
+  on port `8080` by default when `spec.metrics.enabled` is not `false`.
+
+The operator does not proxy or copy job metrics. A `ServiceMonitor` only scrapes
+the operator Service; enable the chart's `PodMonitor` to discover job pods
+directly across namespaces.
+
+Operator metrics include:
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `strimzi_backup_records_total` | Counter | Total records backed up |
-| `strimzi_backup_bytes_total` | Counter | Total bytes backed up |
-| `strimzi_backup_duration_seconds` | Histogram | Backup duration |
-| `strimzi_backup_last_success_timestamp` | Gauge | Last successful backup time |
-| `strimzi_backup_last_failure_timestamp` | Gauge | Last failed backup time |
-| `strimzi_backup_storage_bytes` | Gauge | Total storage used |
-| `strimzi_backup_lag_seconds` | Gauge | Time since last backup |
-| `strimzi_restore_records_total` | Counter | Total records restored |
-| `strimzi_restore_bytes_total` | Counter | Total bytes restored |
-| `strimzi_restore_duration_seconds` | Histogram | Restore duration |
+| `strimzi_backup_operator_build_info` | Gauge | Running operator version |
+| `strimzi_backup_operator_reconciliations_total` | Counter | Reconciliations by controller and result |
+| `strimzi_backup_operator_reconciliation_duration_seconds` | Histogram | Reconciliation latency by controller and result |
+
+Job metrics include `kafka_backup_lag_records`,
+`kafka_backup_records_total`, `kafka_backup_bytes_total`, and the runtime's
+storage, throughput, compression, error, and restore metric families.
 
 ### Prometheus ServiceMonitor
 
@@ -426,7 +434,20 @@ metrics:
     enabled: true
     interval: 30s
     scrapeTimeout: 10s
+  jobPodMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
 ```
+
+The `PodMonitor` requires the Prometheus Operator CRDs and defaults to
+`namespaceSelector.any: true` because backup and restore resources may live
+outside the Helm release namespace. Its endpoint path defaults to `/metrics`;
+if a CR customizes `spec.metrics.path`, provide a matching custom PodMonitor.
+
+One-shot job metrics exist only while the pod is running. Prometheus must scrape
+the pod before it exits; durable last-success reporting should come from the CR
+status or a service-level batch metric store rather than an operator proxy.
 
 ## Disaster Recovery Workflow
 

--- a/README.md
+++ b/README.md
@@ -445,9 +445,19 @@ The `PodMonitor` requires the Prometheus Operator CRDs and defaults to
 outside the Helm release namespace. Its endpoint path defaults to `/metrics`;
 if a CR customizes `spec.metrics.path`, provide a matching custom PodMonitor.
 
-One-shot job metrics exist only while the pod is running. Prometheus must scrape
-the pod before it exits; durable last-success reporting should come from the CR
-status or a service-level batch metric store rather than an operator proxy.
+For a one-shot backup or restore, keep the metrics endpoint alive long enough
+for at least one scrape. A practical minimum is twice the PodMonitor interval:
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+    keepAliveSeconds: 60
+```
+
+This setting is supported by the default `kafka-backup:v0.15.10` job image.
+Durable last-success reporting should still come from the CR status or a
+service-level batch metric store rather than an operator proxy.
 
 ## Disaster Recovery Workflow
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,12 @@ Operator metrics include:
 | `strimzi_backup_operator_reconciliations_total` | Counter | Reconciliations by controller and result |
 | `strimzi_backup_operator_reconciliation_duration_seconds` | Histogram | Reconciliation latency by controller and result |
 
-Job metrics include `kafka_backup_lag_records`,
-`kafka_backup_records_total`, `kafka_backup_bytes_total`, and the runtime's
-storage, throughput, compression, error, and restore metric families.
+Job metrics include `kafka_backup_lag_records`, the low-cardinality
+`kafka_backup_lag_records_sum`, snapshot progress gauges
+`kafka_backup_snapshot_records_target` and
+`kafka_backup_snapshot_records_remaining`, `kafka_backup_records_total`,
+`kafka_backup_bytes_total`, and the runtime's storage, throughput, compression,
+error, and restore metric families.
 
 ### Prometheus ServiceMonitor
 
@@ -453,9 +456,12 @@ spec:
   metrics:
     enabled: true
     keepAliveSeconds: 60
+    maxPartitionLabels: 100
 ```
 
-This setting is supported by the default `kafka-backup:v0.15.10` job image.
+This setting is supported by the default `kafka-backup:v0.15.11` job image.
+`maxPartitionLabels` limits unique topic/partition series; set it to `0` only
+when unlimited per-partition cardinality is intentional.
 Durable last-success reporting should still come from the CR status or a
 service-level batch metric store rather than an operator proxy.
 

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -259,7 +259,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)'
                 nullable: true
                 type: string
               logging:
@@ -313,6 +313,12 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
                     description: Maximum topic/partition labels emitted by the core metrics registry
                     format: uint

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -259,7 +259,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -320,7 +320,7 @@ spec:
                     nullable: true
                     type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -253,7 +253,7 @@ spec:
                     nullable: true
                     type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)'
                 nullable: true
                 type: string
               logging:
@@ -246,6 +246,12 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
                     description: Maximum topic/partition labels emitted by the core metrics registry
                     format: uint

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.14
-appVersion: "0.2.14"
+version: 0.2.15
+appVersion: "0.2.15"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.15
-appVersion: "0.2.15"
+version: 0.2.16
+appVersion: "0.2.16"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -259,7 +259,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)'
                 nullable: true
                 type: string
               logging:
@@ -313,6 +313,12 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
                     description: Maximum topic/partition labels emitted by the core metrics registry
                     format: uint

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -259,7 +259,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -320,7 +320,7 @@ spec:
                     nullable: true
                     type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -253,7 +253,7 @@ spec:
                     nullable: true
                     type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)'
                 nullable: true
                 type: string
               logging:
@@ -246,6 +246,12 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
                     description: Maximum topic/partition labels emitted by the core metrics registry
                     format: uint

--- a/deploy/helm/strimzi-backup-operator/templates/NOTES.txt
+++ b/deploy/helm/strimzi-backup-operator/templates/NOTES.txt
@@ -48,3 +48,8 @@ Metrics are available at:
   kubectl port-forward svc/{{ include "strimzi-backup-operator.fullname" . }}-metrics {{ .Values.service.port }}:{{ .Values.service.port }}
   curl http://localhost:{{ .Values.service.port }}/metrics
 {{- end }}
+{{- if and .Values.metrics.enabled .Values.metrics.jobPodMonitor.enabled }}
+
+Backup and restore job metrics are discovered by PodMonitor
+{{ include "strimzi-backup-operator.fullname" . }}-jobs on the named `metrics` port.
+{{- end }}

--- a/deploy/helm/strimzi-backup-operator/templates/jobpodmonitor.yaml
+++ b/deploy/helm/strimzi-backup-operator/templates/jobpodmonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.enabled .Values.metrics.jobPodMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "strimzi-backup-operator.fullname" . }}-jobs
+  {{- if .Values.metrics.jobPodMonitor.namespace }}
+  namespace: {{ .Values.metrics.jobPodMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "strimzi-backup-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.jobPodMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    {{- toYaml .Values.metrics.jobPodMonitor.namespaceSelector | nindent 4 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: kafka-backup-operator
+      kafkabackup.com/metrics: enabled
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.jobPodMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.jobPodMonitor.scrapeTimeout }}
+      path: {{ .Values.metrics.jobPodMonitor.path }}
+{{- end }}

--- a/deploy/helm/strimzi-backup-operator/values.yaml
+++ b/deploy/helm/strimzi-backup-operator/values.yaml
@@ -100,6 +100,17 @@ metrics:
     interval: 30s
     scrapeTimeout: 10s
     labels: {}
+  # Scrape kafka-backup job pods directly. This is separate from the
+  # ServiceMonitor above, which only scrapes the operator on port 9090.
+  jobPodMonitor:
+    enabled: false
+    namespace: ""
+    namespaceSelector:
+      any: true
+    interval: 30s
+    scrapeTimeout: 10s
+    path: /metrics
+    labels: {}
 
 # CRD installation
 crds:

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -361,6 +361,11 @@ fn build_metrics_options(metrics: &crate::crd::common::MetricsSpec) -> Value {
     }
     insert_u64(
         &mut config,
+        "keep_alive_seconds",
+        metrics.keep_alive_seconds,
+    );
+    insert_u64(
+        &mut config,
         "update_interval_ms",
         metrics.update_interval_ms,
     );
@@ -559,6 +564,21 @@ mod tests {
         assert!(yaml.contains("output: stderr"));
         assert!(yaml.contains("kafka_backup: debug"));
         assert!(yaml.contains("rdkafka: info"));
+    }
+
+    #[test]
+    fn test_build_backup_config_includes_metrics_keep_alive() {
+        let mut backup = test_backup();
+        backup.spec.metrics = Some(MetricsSpec {
+            enabled: Some(true),
+            keep_alive_seconds: Some(60),
+            ..Default::default()
+        });
+
+        let yaml =
+            build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None).unwrap();
+        assert!(yaml.contains("metrics:"));
+        assert!(yaml.contains("keep_alive_seconds: 60"));
     }
 
     /// Issue #35: the kafka-backup binary's config parser only accepts

--- a/src/adapters/restore_config.rs
+++ b/src/adapters/restore_config.rs
@@ -468,6 +468,11 @@ fn build_metrics_options(metrics: &crate::crd::common::MetricsSpec) -> Value {
     }
     insert_u64(
         &mut config,
+        "keep_alive_seconds",
+        metrics.keep_alive_seconds,
+    );
+    insert_u64(
+        &mut config,
         "update_interval_ms",
         metrics.update_interval_ms,
     );

--- a/src/controllers/backup.rs
+++ b/src/controllers/backup.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use futures::StreamExt;
 use k8s_openapi::api::batch::v1::Job;
@@ -30,7 +31,11 @@ async fn reconcile(
     let namespace = backup.namespace().unwrap_or_default();
     info!(%name, %namespace, "Reconciling KafkaBackup");
 
-    reconcile_backup(backup, ctx.client.clone(), &ctx.metrics).await?;
+    let started = Instant::now();
+    let result = reconcile_backup(backup, ctx.client.clone(), &ctx.metrics).await;
+    ctx.metrics
+        .record_reconciliation("backup", result.is_ok(), started.elapsed());
+    result?;
 
     Ok(Action::requeue(Duration::from_secs(300)))
 }

--- a/src/controllers/restore.rs
+++ b/src/controllers/restore.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use futures::StreamExt;
 use k8s_openapi::api::batch::v1::Job;
@@ -30,7 +31,11 @@ async fn reconcile(
     let namespace = restore.namespace().unwrap_or_default();
     info!(%name, %namespace, "Reconciling KafkaRestore");
 
-    reconcile_restore(restore, ctx.client.clone(), &ctx.metrics).await?;
+    let started = Instant::now();
+    let result = reconcile_restore(restore, ctx.client.clone(), &ctx.metrics).await;
+    ctx.metrics
+        .record_reconciliation("restore", result.is_ok(), started.elapsed());
+    result?;
 
     Ok(Action::requeue(Duration::from_secs(300)))
 }

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -228,7 +228,8 @@ pub struct MetricsSpec {
     /// Metrics recalculation interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_interval_ms: Option<u64>,
-    /// Maximum topic/partition labels emitted by the core metrics registry
+    /// Maximum unique topic/partition series emitted by the core metrics registry;
+    /// set to 0 for unlimited series (default: 100)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_partition_labels: Option<usize>,
 }

--- a/src/crd/common.rs
+++ b/src/crd/common.rs
@@ -222,6 +222,9 @@ pub struct MetricsSpec {
     /// Metrics endpoint path
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Seconds to keep serving metrics after a one-shot operation completes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_alive_seconds: Option<u64>,
     /// Metrics recalculation interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_interval_ms: Option<u64>,

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -86,7 +86,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -86,7 +86,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.10)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -82,7 +82,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -82,7 +82,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.10)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/jobs/backup_job.rs
+++ b/src/jobs/backup_job.rs
@@ -10,8 +10,9 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    append_env_overrides, apply_pod_template, build_annotations, build_labels,
-    build_volumes_and_mounts, job_name_env_var, merge_template_labels,
+    add_metrics_discovery_label, append_env_overrides, apply_pod_template, build_annotations,
+    build_labels, build_volumes_and_mounts, job_metrics_ports, job_name_env_var,
+    merge_template_labels,
 };
 
 /// Build a Kubernetes Job spec for a backup operation
@@ -57,6 +58,7 @@ pub fn build_backup_job(
             "/config/backup.yaml".to_string(),
         ]),
         env: if env.is_empty() { None } else { Some(env) },
+        ports: job_metrics_ports(backup.spec.metrics.as_ref()),
         volume_mounts: Some(volume_mounts),
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
@@ -85,6 +87,9 @@ pub fn build_backup_job(
         block_owner_deletion: Some(true),
     };
 
+    let mut pod_labels = build_labels(&cr_name, &cluster.name, "backup");
+    add_metrics_discovery_label(&mut pod_labels, backup.spec.metrics.as_ref());
+
     let job = Job {
         metadata: ObjectMeta {
             name: Some(job_name.to_string()),
@@ -102,7 +107,7 @@ pub fn build_backup_job(
             backoff_limit: Some(backup.spec.backoff_limit.unwrap_or(3)),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
-                    labels: Some(build_labels(&cr_name, &cluster.name, "backup")),
+                    labels: Some(pod_labels),
                     ..Default::default()
                 }),
                 spec: Some(pod_spec),

--- a/src/jobs/cronjob.rs
+++ b/src/jobs/cronjob.rs
@@ -10,8 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    append_env_overrides, apply_pod_template, build_labels, build_volumes_and_mounts,
-    job_name_env_var, merge_template_labels,
+    add_metrics_discovery_label, append_env_overrides, apply_pod_template, build_labels,
+    build_volumes_and_mounts, job_metrics_ports, job_name_env_var, merge_template_labels,
 };
 
 /// Build a Kubernetes CronJob for scheduled backups
@@ -59,6 +59,7 @@ pub fn build_backup_cronjob(
             "/config/backup.yaml".to_string(),
         ]),
         env: if env.is_empty() { None } else { Some(env) },
+        ports: job_metrics_ports(backup.spec.metrics.as_ref()),
         volume_mounts: Some(volume_mounts),
         resources: backup.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
@@ -87,6 +88,9 @@ pub fn build_backup_cronjob(
         block_owner_deletion: Some(true),
     };
 
+    let mut pod_labels = labels.clone();
+    add_metrics_discovery_label(&mut pod_labels, backup.spec.metrics.as_ref());
+
     let cronjob = CronJob {
         metadata: ObjectMeta {
             name: Some(format!("{cr_name}-scheduled")),
@@ -111,7 +115,7 @@ pub fn build_backup_cronjob(
                     backoff_limit: Some(backup.spec.backoff_limit.unwrap_or(3)),
                     template: PodTemplateSpec {
                         metadata: Some(ObjectMeta {
-                            labels: Some(labels),
+                            labels: Some(pod_labels),
                             ..Default::default()
                         }),
                         spec: Some(pod_spec),

--- a/src/jobs/restore_job.rs
+++ b/src/jobs/restore_job.rs
@@ -10,8 +10,8 @@ use crate::strimzi::kafka_cr::ResolvedKafkaCluster;
 use crate::strimzi::kafka_user::ResolvedAuth;
 
 use super::templates::{
-    append_env_overrides, apply_pod_template, build_annotations, build_labels,
-    build_volumes_and_mounts, merge_template_labels,
+    add_metrics_discovery_label, append_env_overrides, apply_pod_template, build_annotations,
+    build_labels, build_volumes_and_mounts, job_metrics_ports, merge_template_labels,
 };
 
 /// Build a Kubernetes Job spec for a restore operation
@@ -61,6 +61,7 @@ pub fn build_restore_job(
             "/config/restore.yaml".to_string(),
         ]),
         env: if env.is_empty() { None } else { Some(env) },
+        ports: job_metrics_ports(restore.spec.metrics.as_ref()),
         volume_mounts: Some(volume_mounts),
         resources: restore.spec.resources.as_ref().map(|r| r.to_k8s()),
         ..Default::default()
@@ -89,6 +90,9 @@ pub fn build_restore_job(
         block_owner_deletion: Some(true),
     };
 
+    let mut pod_labels = build_labels(&cr_name, &cluster.name, "restore");
+    add_metrics_discovery_label(&mut pod_labels, restore.spec.metrics.as_ref());
+
     let job = Job {
         metadata: ObjectMeta {
             name: Some(job_name.to_string()),
@@ -108,7 +112,7 @@ pub fn build_restore_job(
             backoff_limit: Some(restore.spec.backoff_limit.unwrap_or(0)),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
-                    labels: Some(build_labels(&cr_name, &cluster.name, "restore")),
+                    labels: Some(pod_labels),
                     ..Default::default()
                 }),
                 spec: Some(pod_spec),

--- a/src/jobs/templates.rs
+++ b/src/jobs/templates.rs
@@ -1,12 +1,12 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
-    ConfigMapVolumeSource, Container, EnvVar, EnvVarSource, KeyToPath, ObjectFieldSelector,
-    PodSpec, SecretKeySelector, SecretVolumeSource, Volume, VolumeMount,
+    ConfigMapVolumeSource, Container, ContainerPort, EnvVar, EnvVarSource, KeyToPath,
+    ObjectFieldSelector, PodSpec, SecretKeySelector, SecretVolumeSource, Volume, VolumeMount,
 };
 
 use crate::crd::common::{
-    PodTemplateSpec as CrdPodTemplate, SecretKeyRef, StorageSpec, StorageType,
+    MetricsSpec, PodTemplateSpec as CrdPodTemplate, SecretKeyRef, StorageSpec, StorageType,
 };
 use crate::strimzi::kafka_user::ResolvedAuth;
 use crate::strimzi::tls;
@@ -34,6 +34,34 @@ pub fn build_labels(cr_name: &str, cluster_name: &str, job_type: &str) -> BTreeM
     labels.insert("kafkabackup.com/type".to_string(), job_type.to_string());
     labels.insert(format!("kafkabackup.com/{job_type}"), cr_name.to_string());
     labels
+}
+
+/// Whether the kafka-backup runtime metrics server is enabled for this pod.
+/// The runtime defaults metrics to enabled when the section is omitted.
+pub fn job_metrics_enabled(metrics: Option<&MetricsSpec>) -> bool {
+    metrics.and_then(|config| config.enabled).unwrap_or(true)
+}
+
+/// Declare the named port required for Prometheus Operator PodMonitor discovery.
+pub fn job_metrics_ports(metrics: Option<&MetricsSpec>) -> Option<Vec<ContainerPort>> {
+    job_metrics_enabled(metrics).then(|| {
+        vec![ContainerPort {
+            name: Some("metrics".to_string()),
+            container_port: i32::from(metrics.and_then(|config| config.port).unwrap_or(8080)),
+            protocol: Some("TCP".to_string()),
+            ..Default::default()
+        }]
+    })
+}
+
+/// Mark only metrics-enabled job pods for the chart's PodMonitor selector.
+pub fn add_metrics_discovery_label(
+    labels: &mut BTreeMap<String, String>,
+    metrics: Option<&MetricsSpec>,
+) {
+    if job_metrics_enabled(metrics) {
+        labels.insert("kafkabackup.com/metrics".to_string(), "enabled".to_string());
+    }
 }
 
 /// Build the volumes and volume mounts for backup/restore containers.
@@ -476,5 +504,41 @@ mod tests {
         );
         let items = secret.items.as_ref().expect("secret items");
         assert_eq!(items[0].key, "ca.crt");
+    }
+
+    #[test]
+    fn metrics_discovery_uses_runtime_defaults() {
+        let mut labels = BTreeMap::new();
+        add_metrics_discovery_label(&mut labels, None);
+        assert_eq!(
+            labels.get("kafkabackup.com/metrics").map(String::as_str),
+            Some("enabled")
+        );
+
+        let ports = job_metrics_ports(None).expect("metrics default to enabled");
+        assert_eq!(ports[0].name.as_deref(), Some("metrics"));
+        assert_eq!(ports[0].container_port, 8080);
+    }
+
+    #[test]
+    fn metrics_discovery_honors_custom_port_and_disabled_state() {
+        let custom = MetricsSpec {
+            enabled: Some(true),
+            port: Some(9091),
+            ..Default::default()
+        };
+        assert_eq!(
+            job_metrics_ports(Some(&custom)).unwrap()[0].container_port,
+            9091
+        );
+
+        let disabled = MetricsSpec {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        add_metrics_discovery_label(&mut labels, Some(&disabled));
+        assert!(labels.is_empty());
+        assert!(job_metrics_ports(Some(&disabled)).is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,12 @@ async fn main() -> anyhow::Result<()> {
                     "/metrics",
                     get(move || {
                         let state = Arc::clone(&metrics_state);
-                        async move { state.gather() }
+                        async move {
+                            (
+                                [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+                                state.gather(),
+                            )
+                        }
                     }),
                 );
 

--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -1,10 +1,15 @@
 use prometheus::{
-    Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder,
+    Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+    TextEncoder,
 };
+use std::time::Duration;
 
 /// Prometheus metrics state for the operator
 pub struct MetricsState {
     registry: Registry,
+    pub operator_build_info: IntGaugeVec,
+    pub operator_reconciliations_total: IntCounterVec,
+    pub operator_reconciliation_duration_seconds: HistogramVec,
     pub backup_records_total: IntCounterVec,
     pub backup_bytes_total: IntCounterVec,
     pub backup_duration_seconds: HistogramVec,
@@ -26,6 +31,48 @@ impl Default for MetricsState {
 impl MetricsState {
     pub fn new() -> Self {
         let registry = Registry::new();
+
+        // Keep one always-present series so a healthy, idle operator never
+        // serves an empty successful response from /metrics.
+        let operator_build_info = IntGaugeVec::new(
+            Opts::new(
+                "strimzi_backup_operator_build_info",
+                "Build information for the Strimzi backup operator",
+            ),
+            &["version"],
+        )
+        .expect("metric creation");
+        registry
+            .register(Box::new(operator_build_info.clone()))
+            .expect("metric registration");
+        operator_build_info
+            .with_label_values(&[env!("CARGO_PKG_VERSION")])
+            .set(1);
+
+        let operator_reconciliations_total = IntCounterVec::new(
+            Opts::new(
+                "strimzi_backup_operator_reconciliations_total",
+                "Total custom resource reconciliations handled by the operator",
+            ),
+            &["controller", "result"],
+        )
+        .expect("metric creation");
+        registry
+            .register(Box::new(operator_reconciliations_total.clone()))
+            .expect("metric registration");
+
+        let operator_reconciliation_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "strimzi_backup_operator_reconciliation_duration_seconds",
+                "Duration of custom resource reconciliations",
+            )
+            .buckets(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0]),
+            &["controller", "result"],
+        )
+        .expect("metric creation");
+        registry
+            .register(Box::new(operator_reconciliation_duration_seconds.clone()))
+            .expect("metric registration");
 
         let backup_records_total = IntCounterVec::new(
             Opts::new(
@@ -155,6 +202,9 @@ impl MetricsState {
 
         Self {
             registry,
+            operator_build_info,
+            operator_reconciliations_total,
+            operator_reconciliation_duration_seconds,
             backup_records_total,
             backup_bytes_total,
             backup_duration_seconds,
@@ -175,6 +225,18 @@ impl MetricsState {
         let mut buffer = Vec::new();
         encoder.encode(&metric_families, &mut buffer).unwrap();
         String::from_utf8(buffer).unwrap()
+    }
+
+    /// Record one controller reconciliation and its result.
+    pub fn record_reconciliation(&self, controller: &str, succeeded: bool, duration: Duration) {
+        let result = if succeeded { "success" } else { "error" };
+        let labels = &[controller, result];
+        self.operator_reconciliations_total
+            .with_label_values(labels)
+            .inc();
+        self.operator_reconciliation_duration_seconds
+            .with_label_values(labels)
+            .observe(duration.as_secs_f64());
     }
 
     /// Record a successful backup completion
@@ -239,8 +301,20 @@ mod tests {
     fn test_metrics_creation() {
         let state = MetricsState::new();
         let output = state.gather();
-        // Should contain metric definitions even without data
-        assert!(output.is_empty() || output.contains("strimzi_backup"));
+        assert!(output.contains("strimzi_backup_operator_build_info"));
+        assert!(output.contains(&format!("version=\"{}\"", env!("CARGO_PKG_VERSION"))));
+    }
+
+    #[test]
+    fn test_record_reconciliation() {
+        let state = MetricsState::new();
+        state.record_reconciliation("backup", true, Duration::from_millis(125));
+
+        let output = state.gather();
+        assert!(output.contains(
+            "strimzi_backup_operator_reconciliations_total{controller=\"backup\",result=\"success\"} 1"
+        ));
+        assert!(output.contains("strimzi_backup_operator_reconciliation_duration_seconds_count"));
     }
 
     #[test]

--- a/src/reconcilers/backup.rs
+++ b/src/reconcilers/backup.rs
@@ -19,8 +19,8 @@ use crate::jobs::cronjob::build_backup_cronjob;
 use crate::jobs::job_state::{classify_jobs, job_failed, job_succeeded, should_create_backup_job};
 use crate::metrics::prometheus::MetricsState;
 use crate::reconcilers::{
-    cleanup_delete_params, job_service_account_name, FINALIZER, TRIGGER_ANNOTATION,
-    TRIGGER_VALUE_NOW,
+    cleanup_delete_params, is_reconciliation_paused, job_service_account_name, FINALIZER,
+    TRIGGER_ANNOTATION, TRIGGER_VALUE_NOW,
 };
 use crate::retention::policy::evaluate_retention;
 use crate::retention::storage::{discover_backup_history, prune_backup_ids};
@@ -43,6 +43,16 @@ pub async fn reconcile_backup(
     // Check if being deleted
     if backup.metadata.deletion_timestamp.is_some() {
         return handle_cleanup(&backup, &client, &namespace).await;
+    }
+
+    // Match Strimzi's pause semantics: a newly created paused resource is
+    // status-only and must not gain a finalizer, ConfigMap, Job, or CronJob.
+    // Deletion is intentionally handled first so an existing finalizer cannot
+    // strand a resource that is deleted while paused.
+    if is_reconciliation_paused(backup.as_ref()) {
+        update_status_reconciliation_paused(&backup_api, &backup).await?;
+        info!(%name, "Reconciliation paused by annotation");
+        return Ok(());
     }
 
     // Ensure finalizer is set
@@ -482,6 +492,25 @@ async fn update_status_running(api: &Api<KafkaBackup>, name: &str, generation: i
     status.conditions = vec![not_ready(REASON_BACKUP_RUNNING, "Backup job is running")];
     status.observed_generation = Some(generation);
     patch_status(api, name, &status).await
+}
+
+async fn update_status_reconciliation_paused(
+    api: &Api<KafkaBackup>,
+    backup: &KafkaBackup,
+) -> Result<()> {
+    let name = backup.name_any();
+    let generation = backup.metadata.generation.unwrap_or(0);
+    let mut status = backup.status.clone().unwrap_or_default();
+    let already_current =
+        is_condition_true(&status.conditions, CONDITION_TYPE_RECONCILIATION_PAUSED)
+            && status.observed_generation == Some(generation);
+    if already_current {
+        return Ok(());
+    }
+
+    status.conditions = vec![reconciliation_paused()];
+    status.observed_generation = Some(generation);
+    patch_status(api, &name, &status).await
 }
 
 async fn update_status_scheduled(

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -22,7 +22,7 @@ pub fn is_reconciliation_paused<K: kube::ResourceExt>(resource: &K) -> bool {
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.
-pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.10";
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.11";
 
 /// Environment variable used by the Helm chart to pass the service account that
 /// backup/restore job pods should run as.

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -22,7 +22,7 @@ pub fn is_reconciliation_paused<K: kube::ResourceExt>(resource: &K) -> bool {
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.
-pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.6";
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.10";
 
 /// Environment variable used by the Helm chart to pass the service account that
 /// backup/restore job pods should run as.

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -8,6 +8,17 @@ pub const FINALIZER: &str = "kafkabackup.com/cleanup";
 pub const TRIGGER_ANNOTATION: &str = "kafkabackup.com/trigger";
 pub const TRIGGER_VALUE_NOW: &str = "now";
 
+/// Strimzi-compatible annotation for temporarily suppressing reconciliation.
+pub const PAUSE_RECONCILIATION_ANNOTATION: &str = "strimzi.io/pause-reconciliation";
+
+/// Return whether a custom resource has explicitly paused reconciliation.
+pub fn is_reconciliation_paused<K: kube::ResourceExt>(resource: &K) -> bool {
+    resource
+        .annotations()
+        .get(PAUSE_RECONCILIATION_ANNOTATION)
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.

--- a/src/reconcilers/restore.rs
+++ b/src/reconcilers/restore.rs
@@ -16,7 +16,9 @@ use crate::error::{Error, Result};
 use crate::jobs::job_state::{classify_jobs, JobsState};
 use crate::jobs::restore_job::build_restore_job;
 use crate::metrics::prometheus::MetricsState;
-use crate::reconcilers::{cleanup_delete_params, job_service_account_name, FINALIZER};
+use crate::reconcilers::{
+    cleanup_delete_params, is_reconciliation_paused, job_service_account_name, FINALIZER,
+};
 use crate::status::conditions::*;
 use crate::strimzi::kafka_cr::resolve_kafka_cluster;
 use crate::strimzi::kafka_user::resolve_auth;
@@ -36,6 +38,14 @@ pub async fn reconcile_restore(
     // Check if being deleted
     if restore.metadata.deletion_timestamp.is_some() {
         return handle_cleanup(&restore, &client, &namespace).await;
+    }
+
+    // Keep deletion cleanup available while paused, but otherwise perform no
+    // resource mutations beyond reporting the Strimzi-compatible condition.
+    if is_reconciliation_paused(restore.as_ref()) {
+        update_status_reconciliation_paused(&restore_api, &restore).await?;
+        info!(%name, "Reconciliation paused by annotation");
+        return Ok(());
     }
 
     // Ensure finalizer
@@ -336,6 +346,25 @@ async fn update_status_running(api: &Api<KafkaRestore>, name: &str, generation: 
         ..Default::default()
     };
     patch_status(api, name, &status).await
+}
+
+async fn update_status_reconciliation_paused(
+    api: &Api<KafkaRestore>,
+    restore: &KafkaRestore,
+) -> Result<()> {
+    let name = restore.name_any();
+    let generation = restore.metadata.generation.unwrap_or(0);
+    let mut status = restore.status.clone().unwrap_or_default();
+    let already_current =
+        is_condition_true(&status.conditions, CONDITION_TYPE_RECONCILIATION_PAUSED)
+            && status.observed_generation == Some(generation);
+    if already_current {
+        return Ok(());
+    }
+
+    status.conditions = vec![reconciliation_paused()];
+    status.observed_generation = Some(generation);
+    patch_status(api, &name, &status).await
 }
 
 async fn update_status_completed(

--- a/src/status/conditions.rs
+++ b/src/status/conditions.rs
@@ -8,6 +8,7 @@ pub const CONDITION_TYPE_BACKUP_COMPLETE: &str = "BackupComplete";
 pub const CONDITION_TYPE_RESTORE_COMPLETE: &str = "RestoreComplete";
 pub const CONDITION_TYPE_SCHEDULED: &str = "Scheduled";
 pub const CONDITION_TYPE_ERROR: &str = "Error";
+pub const CONDITION_TYPE_RECONCILIATION_PAUSED: &str = "ReconciliationPaused";
 
 /// Condition status values
 pub const STATUS_TRUE: &str = "True";
@@ -27,6 +28,7 @@ pub const REASON_RESTORE_FAILED: &str = "RestoreFailed";
 pub const REASON_CLUSTER_NOT_FOUND: &str = "ClusterNotFound";
 pub const REASON_INVALID_CONFIG: &str = "InvalidConfiguration";
 pub const REASON_SECRET_NOT_FOUND: &str = "SecretNotFound";
+pub const REASON_RECONCILIATION_PAUSED: &str = "ReconciliationPaused";
 
 /// Create a new condition
 pub fn new_condition(condition_type: &str, status: &str, reason: &str, message: &str) -> Condition {
@@ -81,6 +83,16 @@ pub fn ready(reason: &str, message: &str) -> Condition {
 /// Create a Ready=False condition
 pub fn not_ready(reason: &str, message: &str) -> Condition {
     new_condition(CONDITION_TYPE_READY, STATUS_FALSE, reason, message)
+}
+
+/// Create the condition used while the Strimzi pause annotation is enabled.
+pub fn reconciliation_paused() -> Condition {
+    new_condition(
+        CONDITION_TYPE_RECONCILIATION_PAUSED,
+        STATUS_TRUE,
+        REASON_RECONCILIATION_PAUSED,
+        "Reconciliation is paused by annotation",
+    )
 }
 
 /// Create an error condition (sets Ready=False and adds Error condition)

--- a/tests/integration/backup_test.rs
+++ b/tests/integration/backup_test.rs
@@ -202,6 +202,25 @@ fn test_backup_job_creation() {
     );
     assert_eq!(pod_spec.containers.len(), 1);
     assert_eq!(pod_spec.containers[0].name, "backup");
+    let metrics_port = pod_spec.containers[0]
+        .ports
+        .as_ref()
+        .and_then(|ports| {
+            ports
+                .iter()
+                .find(|port| port.name.as_deref() == Some("metrics"))
+        })
+        .expect("metrics-enabled backup pod should declare its scrape port");
+    assert_eq!(metrics_port.container_port, 8080);
+    assert_eq!(
+        spec.template
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.labels.as_ref())
+            .and_then(|labels| labels.get("kafkabackup.com/metrics"))
+            .map(String::as_str),
+        Some("enabled")
+    );
     assert!(pod_spec.containers[0]
         .args
         .as_ref()
@@ -254,6 +273,12 @@ fn test_backup_cronjob_uses_configured_service_account() {
     assert_eq!(
         pod_spec.service_account_name.as_deref(),
         Some("strimzi-backup-operator")
+    );
+    assert_eq!(
+        pod_spec.containers[0].ports.as_ref().unwrap()[0]
+            .name
+            .as_deref(),
+        Some("metrics")
     );
     assert!(pod_spec.containers[0]
         .env

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,5 +2,6 @@ mod backup_test;
 mod cleanup_test;
 mod job_state_test;
 mod reconcile_backup_test;
+mod reconcile_pause_test;
 mod restore_test;
 mod strimzi_api_test;

--- a/tests/integration/reconcile_pause_test.rs
+++ b/tests/integration/reconcile_pause_test.rs
@@ -1,0 +1,192 @@
+use std::sync::{Arc, Mutex};
+
+use http::{Request, Response};
+use http_body_util::BodyExt;
+use kafka_backup_operator::crd::common::{
+    FilesystemStorageSpec, StorageSpec, StorageType, StrimziClusterRef,
+};
+use kafka_backup_operator::crd::kafka_backup::KafkaBackupSpec;
+use kafka_backup_operator::crd::kafka_restore::{BackupRef, KafkaRestoreSpec};
+use kafka_backup_operator::crd::{KafkaBackup, KafkaRestore};
+use kafka_backup_operator::metrics::prometheus::MetricsState;
+use kafka_backup_operator::reconcilers::backup::reconcile_backup;
+use kafka_backup_operator::reconcilers::restore::reconcile_restore;
+use kube::client::Body;
+use kube::Client;
+use serde::Serialize;
+use serde_json::json;
+use tower_test::mock;
+
+#[derive(Debug)]
+struct RecordedRequest {
+    method: String,
+    path: String,
+    body: serde_json::Value,
+}
+
+fn cluster_ref() -> StrimziClusterRef {
+    StrimziClusterRef {
+        name: "missing-after-disaster".to_string(),
+        namespace: None,
+        ca_secret: None,
+        listener: None,
+    }
+}
+
+fn paused_backup() -> KafkaBackup {
+    let spec = KafkaBackupSpec {
+        strimzi_cluster_ref: cluster_ref(),
+        authentication: None,
+        topics: None,
+        connection: None,
+        consumer_groups: None,
+        logging: None,
+        env: Vec::new(),
+        storage: StorageSpec {
+            storage_type: StorageType::Filesystem,
+            s3: None,
+            azure: None,
+            gcs: None,
+            filesystem: Some(FilesystemStorageSpec {
+                path: "/backups".to_string(),
+            }),
+        },
+        backup: None,
+        metrics: None,
+        offset_storage: None,
+        schedule: None,
+        retention: None,
+        resources: None,
+        template: None,
+        image: None,
+        backoff_limit: None,
+    };
+    let mut backup = KafkaBackup::new("restore-source", spec);
+    backup.metadata.namespace = Some("kafka".to_string());
+    backup.metadata.uid = Some("backup-uid".to_string());
+    backup.metadata.generation = Some(1);
+    backup.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        "strimzi.io/pause-reconciliation".to_string(),
+        "true".to_string(),
+    )]));
+    backup
+}
+
+fn paused_restore() -> KafkaRestore {
+    let spec = KafkaRestoreSpec {
+        strimzi_cluster_ref: cluster_ref(),
+        authentication: None,
+        backup_ref: BackupRef {
+            name: "restore-source".to_string(),
+            backup_id: Some("snapshot-before-disaster".to_string()),
+        },
+        topics: None,
+        point_in_time: None,
+        connection: None,
+        logging: None,
+        env: Vec::new(),
+        topic_mapping: Vec::new(),
+        consumer_groups: None,
+        restore: None,
+        metrics: None,
+        resources: None,
+        template: None,
+        image: None,
+        backoff_limit: None,
+    };
+    let mut restore = KafkaRestore::new("disaster-restore", spec);
+    restore.metadata.namespace = Some("kafka".to_string());
+    restore.metadata.uid = Some("restore-uid".to_string());
+    restore.metadata.generation = Some(1);
+    restore.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        "strimzi.io/pause-reconciliation".to_string(),
+        "TRUE".to_string(),
+    )]));
+    restore
+}
+
+async fn reconcile_paused_resource<K, F, Fut>(resource: K, reconcile: F) -> Vec<RecordedRequest>
+where
+    K: Serialize,
+    F: FnOnce(Client, MetricsState) -> Fut,
+    Fut: std::future::Future<Output = kafka_backup_operator::error::Result<()>>,
+{
+    let (mock_service, mut handle) = mock::pair::<Request<Body>, Response<Body>>();
+    let recorded = Arc::new(Mutex::new(Vec::new()));
+    let resource_json = serde_json::to_value(resource).unwrap();
+
+    let dispatcher = {
+        let recorded = Arc::clone(&recorded);
+        tokio::spawn(async move {
+            while let Some((request, send)) = handle.next_request().await {
+                let method = request.method().to_string();
+                let path = request.uri().path().to_string();
+                let bytes = request.into_body().collect().await.unwrap().to_bytes();
+                let body = if bytes.is_empty() {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::from_slice(&bytes).unwrap()
+                };
+
+                recorded
+                    .lock()
+                    .unwrap()
+                    .push(RecordedRequest { method, path, body });
+
+                let response = Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&resource_json).unwrap()))
+                    .unwrap();
+                send.send_response(response);
+            }
+        })
+    };
+
+    let client = Client::new(mock_service, "kafka");
+    reconcile(client, MetricsState::new())
+        .await
+        .expect("paused reconciliation should succeed");
+    dispatcher.await.unwrap();
+    Arc::try_unwrap(recorded).unwrap().into_inner().unwrap()
+}
+
+fn assert_status_only(requests: &[RecordedRequest], resource_plural: &str, name: &str) {
+    assert_eq!(requests.len(), 1, "a paused resource must be status-only");
+    let request = &requests[0];
+    assert_eq!(request.method, "PATCH");
+    assert!(request
+        .path
+        .ends_with(&format!("/{resource_plural}/{name}/status")));
+    assert_eq!(
+        request.body["status"]["conditions"][0]["type"],
+        json!("ReconciliationPaused")
+    );
+    assert_eq!(
+        request.body["status"]["conditions"][0]["status"],
+        json!("True")
+    );
+    assert_eq!(request.body["status"]["observedGeneration"], json!(1));
+}
+
+#[tokio::test]
+async fn paused_backup_does_not_create_operator_resources() {
+    let backup = paused_backup();
+    let requests = reconcile_paused_resource(backup.clone(), move |client, metrics| async move {
+        reconcile_backup(Arc::new(backup), client, &metrics).await
+    })
+    .await;
+
+    assert_status_only(&requests, "kafkabackups", "restore-source");
+}
+
+#[tokio::test]
+async fn paused_restore_does_not_resolve_dependencies_or_create_a_job() {
+    let restore = paused_restore();
+    let requests = reconcile_paused_resource(restore.clone(), move |client, metrics| async move {
+        reconcile_restore(Arc::new(restore), client, &metrics).await
+    })
+    .await;
+
+    assert_status_only(&requests, "kafkarestores", "disaster-restore");
+}

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -252,6 +252,25 @@ fn test_restore_job_creation() {
         Some("strimzi-backup-operator")
     );
     assert_eq!(pod_spec.containers[0].name, "restore");
+    let metrics_port = pod_spec.containers[0]
+        .ports
+        .as_ref()
+        .and_then(|ports| {
+            ports
+                .iter()
+                .find(|port| port.name.as_deref() == Some("metrics"))
+        })
+        .expect("metrics-enabled restore pod should declare its scrape port");
+    assert_eq!(metrics_port.container_port, 8080);
+    assert_eq!(
+        job.spec
+            .as_ref()
+            .and_then(|spec| spec.template.metadata.as_ref())
+            .and_then(|metadata| metadata.labels.as_ref())
+            .and_then(|labels| labels.get("kafkabackup.com/metrics"))
+            .map(String::as_str),
+        Some("enabled")
+    );
     assert!(pod_spec.containers[0]
         .args
         .as_ref()

--- a/tests/integration/restore_test.rs
+++ b/tests/integration/restore_test.rs
@@ -205,6 +205,28 @@ fn test_restore_logging_config_generation() {
 }
 
 #[test]
+fn test_restore_metrics_keep_alive_generation() {
+    let mut restore = sample_restore();
+    restore.spec.metrics = Some(MetricsSpec {
+        enabled: Some(true),
+        keep_alive_seconds: Some(60),
+        ..Default::default()
+    });
+
+    let yaml = build_restore_config_yaml(
+        &restore,
+        &sample_backup(),
+        &sample_cluster(),
+        &None,
+        &ResolvedAuth::None,
+    )
+    .unwrap();
+
+    assert!(yaml.contains("metrics:"));
+    assert!(yaml.contains("keep_alive_seconds: 60"));
+}
+
+#[test]
 fn test_restore_job_creation() {
     let mut restore = sample_restore();
     restore.spec.env.push(serde_json::json!({


### PR DESCRIPTION
## Summary

- make the operator `/metrics` endpoint non-empty while idle with a build-info gauge, and record reconciliation totals/durations by controller and result
- expose the configured `kafka-backup` metrics port on generated backup, restore, and scheduled containers
- label metrics-enabled job pods and add an opt-in cross-namespace Helm `PodMonitor`
- add `spec.metrics.keepAliveSeconds` for reliably scraping one-shot jobs
- update the default runtime to released `kafka-backup:v0.15.11`, including corrected unique-series cardinality accounting, unlimited mode with `maxPartitionLabels: 0`, aggregate continuous lag, and snapshot target/remaining metrics
- clearly separate operator `ServiceMonitor` metrics on `:9090` from runtime job metrics on `:8080` in the documentation
- prepare release `0.2.16`, including generated raw and Helm CRDs

## Triage

These are confirmed bugs plus a monitoring integration gap. The operator registered only uninstantiated metric vectors and both reconcilers ignored the metrics state, so a healthy scrape returned HTTP 200 with an empty body. Separately, `spec.metrics` enables the metrics server inside each `kafka-backup` job; the existing chart `ServiceMonitor` selects only the operator Service and cannot scrape those pods. Direct pod discovery with a `PodMonitor` keeps high-cardinality runtime metrics at their source, while a bounded post-completion window makes one-shot jobs scrapeable.

Issue #45 also reproduced two runtime defects: the limit counted metric update calls rather than unique topic/partition series, and snapshot backups exposed no target/remaining gauges. Those runtime fixes shipped in osodevops/kafka-backup#131 and are consumed here through the released v0.15.11 image.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-features` (99 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- CRD regeneration and exact raw/chart CRD parity
- Helm lint, default render, ServiceMonitor render, and PodMonitor render
- production Docker image build, non-root UID, executable/linkage smoke tests
- disposable Kubernetes 1.36 Kind install from the locally built image: deployment reached 1/1 Ready with zero restarts; `/healthz`, `/readyz`, and `/metrics` all succeeded
- live operator scrape included `strimzi_backup_operator_build_info{version="0.2.16"} 1`
- released `osodevops/kafka-backup:v0.15.11` image manifest and GitHub release verified
- the one-shot scrape window and progress/cardinality behavior were exercised against the Kafka Docker Compose stack in osodevops/kafka-backup#131

Fixes #43
Fixes #45
