### PR TITLE
fix: remove enterprise encryption from OSS CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Remove the unsupported `spec.backup.encryption` field from the OSS API and
+  generated CRDs. Client-side backup encryption is an Enterprise Edition
+  capability; exposing it here caused reconciliation to fail instead of
+  creating a backup Job. A schema-hidden compatibility guard keeps older
+  installed CRDs fail-closed rather than silently running an unencrypted
+  backup. Fixes [#48](https://github.com/osodevops/strimzi-backup-operator/issues/48).
+
 ## 0.2.16 - 2026-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.2.17 - 2026-07-21
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -103,7 +103,7 @@ spec:
                 nullable: true
                 type: integer
               backup:
-                description: Backup options (compression, encryption, parallelism)
+                description: Backup options (compression, parallelism, checkpointing)
                 nullable: true
                 properties:
                   checkpointIntervalSecs:
@@ -129,29 +129,6 @@ spec:
                     description: Run continuously instead of one-shot
                     nullable: true
                     type: boolean
-                  encryption:
-                    description: Encryption configuration
-                    nullable: true
-                    properties:
-                      enabled:
-                        default: false
-                        description: Enable encryption
-                        type: boolean
-                      keySecret:
-                        description: Secret containing the encryption key
-                        nullable: true
-                        properties:
-                          key:
-                            description: Key within the secret
-                            type: string
-                          name:
-                            description: Secret name
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    type: object
                   includeInternalTopics:
                     description: Include internal Kafka topics
                     nullable: true

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.16
-appVersion: "0.2.16"
+version: 0.2.17
+appVersion: "0.2.17"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -103,7 +103,7 @@ spec:
                 nullable: true
                 type: integer
               backup:
-                description: Backup options (compression, encryption, parallelism)
+                description: Backup options (compression, parallelism, checkpointing)
                 nullable: true
                 properties:
                   checkpointIntervalSecs:
@@ -129,29 +129,6 @@ spec:
                     description: Run continuously instead of one-shot
                     nullable: true
                     type: boolean
-                  encryption:
-                    description: Encryption configuration
-                    nullable: true
-                    properties:
-                      enabled:
-                        default: false
-                        description: Enable encryption
-                        type: boolean
-                      keySecret:
-                        description: Secret containing the encryption key
-                        nullable: true
-                        properties:
-                          key:
-                            description: Key within the secret
-                            type: string
-                          name:
-                            description: Secret name
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    type: object
                   includeInternalTopics:
                     description: Include internal Kafka topics
                     nullable: true

--- a/docs/strimzi-backup-operator-prd.md
+++ b/docs/strimzi-backup-operator-prd.md
@@ -163,12 +163,7 @@ spec:
 
   # Backup configuration
   backup:
-    compression: zstd           # none | gzip | snappy | lz4 | zstd
-    encryption:
-      enabled: false
-      keySecret:
-        name: backup-encryption-key
-        key: aes-256-key
+    compression: zstd           # none | lz4 | zstd
     segmentSize: 268435456      # 256MB — max segment file size before rotation
     parallelism: 4              # Number of concurrent partition backup threads
 
@@ -520,8 +515,7 @@ rules:
 ### 6.2 Encryption
 
 - **In-transit**: TLS for all Kafka connections, leveraging Strimzi cluster CA certificates.
-- **At-rest**: Optional AES-256-GCM encryption of backup segments before storage upload.
-- **Key management**: Encryption keys stored in Kubernetes Secrets, with future support for external KMS (AWS KMS, Azure Key Vault, HashiCorp Vault).
+- **At-rest**: Client-side backup encryption is an Enterprise Edition capability and is not exposed by this OSS operator.
 
 ### 6.3 Network Policies
 
@@ -619,7 +613,6 @@ kubectl apply -f https://operatorhub.io/install/strimzi-backup-operator.yaml
 - [ ] `KafkaBackupSchedule` CRD for multi-cluster policies
 - [ ] Consumer group offset backup and restore
 - [ ] Topic mapping during restore (rename, repartition)
-- [ ] At-rest encryption (AES-256-GCM)
 - [ ] `KafkaUser` CR integration for automatic credential discovery
 - [ ] Grafana dashboard
 - [ ] OLM / OperatorHub publication
@@ -627,6 +620,7 @@ kubectl apply -f https://operatorhub.io/install/strimzi-backup-operator.yaml
 
 ### v0.3.0 — Enterprise (8 weeks after v0.2.0)
 
+- [ ] Client-side at-rest encryption (AES-256-GCM)
 - [ ] Schema Registry backup and restore
 - [ ] External KMS integration (AWS KMS, Azure Key Vault, Vault)
 - [ ] RBAC and multi-tenancy support

--- a/src/adapters/backup_config.rs
+++ b/src/adapters/backup_config.rs
@@ -196,7 +196,7 @@ fn build_backup_options(opts: &crate::crd::kafka_backup::BackupOptionsSpec) -> R
 
     if opts.encryption.as_ref().is_some_and(|e| e.enabled) {
         return Err(Error::InvalidConfig(
-            "backup.encryption is not supported by the current kafka-backup core config"
+            "spec.backup.encryption is an Enterprise Edition capability and is not supported by the OSS Strimzi operator"
                 .to_string(),
         ));
     }
@@ -540,6 +540,28 @@ mod tests {
         assert!(yaml.contains("mode: backup"));
         assert!(yaml.contains("bootstrap_servers:"));
         assert!(yaml.contains("orders.*"));
+    }
+
+    #[test]
+    fn test_build_backup_config_rejects_encryption_from_stale_crd() {
+        let mut backup = serde_json::to_value(test_backup()).unwrap();
+        backup["spec"]["backup"]["encryption"] = serde_json::json!({
+            "enabled": true,
+            "keySecret": {
+                "name": "backup-encryption-key",
+                "key": "aes-256-key"
+            }
+        });
+        let backup: KafkaBackup = serde_json::from_value(backup).unwrap();
+
+        let error = build_backup_config_yaml(&backup, &test_cluster(), &None, &ResolvedAuth::None)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidConfig(message)
+                if message == "spec.backup.encryption is an Enterprise Edition capability and is not supported by the OSS Strimzi operator"
+        ));
     }
 
     #[test]

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::common::{
     AuthenticationSpec, BackupHistoryEntry, Condition, ConsumerGroupSelection, KafkaConnectionSpec,
     LastBackupInfo, LoggingSpec, MetricsSpec, OffsetStorageSpec, PodTemplateSpec,
-    ResourceRequirementsSpec, SecretKeyRef, StorageSpec, StrimziClusterRef, TopicSelection,
+    ResourceRequirementsSpec, StorageSpec, StrimziClusterRef, TopicSelection,
 };
 
 /// KafkaBackup defines a backup configuration for a Strimzi-managed Kafka cluster.
@@ -58,7 +58,7 @@ pub struct KafkaBackupSpec {
     /// Storage destination configuration
     pub storage: StorageSpec,
 
-    /// Backup options (compression, encryption, parallelism)
+    /// Backup options (compression, parallelism, checkpointing)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup: Option<BackupOptionsSpec>,
 
@@ -110,9 +110,15 @@ pub struct BackupOptionsSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compression_level: Option<i32>,
 
-    /// Encryption configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub encryption: Option<EncryptionSpec>,
+    /// Legacy deserialization guard for CRDs installed before issue #48.
+    ///
+    /// This is deliberately absent from the generated CRD schema. Keeping the
+    /// input-only field lets the operator fail closed when an older installed
+    /// CRD still accepts the unsupported encryption configuration.
+    #[doc(hidden)]
+    #[schemars(skip)]
+    #[serde(default, skip_serializing)]
+    pub encryption: Option<UnsupportedEncryptionSpec>,
 
     /// Maximum segment file size in bytes before rotation (default: 256MB)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,16 +177,11 @@ pub struct BackupOptionsSpec {
     pub consumer_group_snapshot: Option<bool>,
 }
 
-/// Encryption configuration for backups
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct EncryptionSpec {
-    /// Enable encryption
+#[doc(hidden)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UnsupportedEncryptionSpec {
     #[serde(default)]
     pub enabled: bool,
-    /// Secret containing the encryption key
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub key_secret: Option<SecretKeyRef>,
 }
 
 /// Cron schedule for periodic backups
@@ -235,4 +236,24 @@ pub struct KafkaBackupStatus {
     /// Next scheduled backup time
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_scheduled_backup: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use kube::CustomResourceExt;
+
+    use super::KafkaBackup;
+
+    #[test]
+    fn crd_does_not_expose_unsupported_encryption() {
+        let crd = serde_json::to_value(KafkaBackup::crd()).expect("CRD should serialize");
+        let encryption = crd.pointer(
+            "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/backup/properties/encryption",
+        );
+
+        assert!(
+            encryption.is_none(),
+            "the OSS Strimzi operator must not expose enterprise-only encryption"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- remove unsupported `spec.backup.encryption` from the public OSS CRD and Helm CRD
- retain a schema-hidden input guard so stale installed CRDs fail closed instead of silently creating an unencrypted backup
- document the Enterprise Edition boundary and add regression coverage for both the generated schema and stale-CRD payloads
- prepare release metadata for operator and chart version `0.2.17`

## Triage

The `kafka-backup` OSS core used by v0.2.16 has no backup encryption config. Its project documentation classifies client-side AES encryption at rest as an Enterprise Edition capability, and the enterprise distribution gates encryption behind the `encryption` license feature. The Strimzi field was left over from the original roadmap and must not be implemented in this OSS operator.

## Reproduction and safety

Before the fix, the new CRD-schema regression test failed because `spec.backup.encryption` was present. After the fix it is absent from both generated CRD copies.

Helm does not upgrade installed CRDs automatically. The input-only compatibility guard therefore still recognizes an enabled encryption block admitted by an older CRD and returns an explicit Enterprise-only error. This prevents an operator-only upgrade from silently running the backup without encryption.

## Local validation

- `bash scripts/release-gate.sh` — version, tag, chart, and changelog metadata passed for `0.2.17`
- `cargo fmt --all -- --check`
- `cargo test` — 52 unit tests and 49 integration tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `helm template strimzi-backup-operator deploy/helm/strimzi-backup-operator`
- generated CRDs match the Helm CRD copies
- `git diff --check`

Fixes #48