### PR TITLE
fix: consume kafka-backup v0.15.12 metric fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.18 - 2026-07-21
+
+### Fixed
+
+- Update the default job image to `osodevops/kafka-backup:v0.15.12`, which
+  labels storage write metrics with the storage backend actually written to
+  (`s3`, `azure`, `gcs`, …) instead of a hardcoded `filesystem`, and exposes
+  counters under the documented single-`_total` names (for example
+  `kafka_backup_records_total` rather than
+  `kafka_backup_records_total_total`). Dashboards built on the doubled names
+  must move to the documented names. Fixes
+  [#50](https://github.com/osodevops/strimzi-backup-operator/issues/50).
+
 ## 0.2.17 - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-operator"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-backup-operator"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ spec:
     maxPartitionLabels: 100
 ```
 
-This setting is supported by the default `kafka-backup:v0.15.11` job image.
+This setting is supported by the default `kafka-backup:v0.15.12` job image.
 `maxPartitionLabels` limits unique topic/partition series; set it to `0` only
 when unlimited per-partition cardinality is intentional.
 Durable last-success reporting should still come from the CR status or a

--- a/deploy/crds/kafkabackups.yaml
+++ b/deploy/crds/kafkabackups.yaml
@@ -236,7 +236,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/crds/kafkarestores.yaml
+++ b/deploy/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/helm/strimzi-backup-operator/Chart.yaml
+++ b/deploy/helm/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.17
-appVersion: "0.2.17"
+version: 0.2.18
+appVersion: "0.2.18"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -236,7 +236,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:

--- a/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/deploy/helm/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:

--- a/src/crd/kafka_backup.rs
+++ b/src/crd/kafka_backup.rs
@@ -86,7 +86,7 @@ pub struct KafkaBackupSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)
+    /// Container image for the backup job (default: osodevops/kafka-backup:v0.15.12)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/crd/kafka_restore.rs
+++ b/src/crd/kafka_restore.rs
@@ -82,7 +82,7 @@ pub struct KafkaRestoreSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<PodTemplateSpec>,
 
-    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)
+    /// Container image for the restore job (default: osodevops/kafka-backup:v0.15.12)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -22,7 +22,7 @@ pub fn is_reconciliation_paused<K: kube::ResourceExt>(resource: &K) -> bool {
 /// Default backup image. Pinned to a public, current kafka-backup release so
 /// backup/restore job behavior is deterministic and the image is anonymously
 /// pullable by Kubernetes.
-pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.11";
+pub const DEFAULT_BACKUP_IMAGE: &str = "osodevops/kafka-backup:v0.15.12";
 
 /// Environment variable used by the Helm chart to pass the service account that
 /// backup/restore job pods should run as.


### PR DESCRIPTION
## Summary

Closes #50. Bumps the default job image to `osodevops/kafka-backup:v0.15.12` (osodevops/kafka-backup#134), which fixes the two live metric defects:

- `kafka_backup_storage_write_bytes` was labelled `backend="filesystem"` even when segments were streamed to S3 — the label now reflects the backend actually written to. (To answer the reporter's minor question directly: segments were never spooled to disk; only the label was wrong, no PVC needed.)
- Counters no longer carry the doubled `_total_total` suffix; exposed series now match the documented `kafka_backup_*_total` names. **Dashboards built on the doubled names must be updated.**

## Root cause of the "static" gauges

The major symptom in #50 — frozen `kafka_backup_lag_records` / `kafka_backup_lag_records_sum` / `kafka_backup_snapshot_records_remaining` while `kafka_backup_records_total*` kept climbing — is the cardinality-budget freeze fixed in kafka-backup v0.15.11 (see #45): on v0.15.10 every gauge *update* consumed one of the 100 label-budget slots, so all lag gauges froze at their initial values a few seconds into the run. Reproduced both behaviours locally (3.2M records, snapshot mode, MinIO, 400ms scrapes): v0.15.10 freezes exactly as reported; v0.15.11+ counts down correctly (`snapshot_records_remaining` 3,191,285 → 0). A day-long job started before the v0.15.11 rollout (operator ≤0.2.15) keeps its old image until the Job is recreated — the reporter should delete/recreate the running backup Job after upgrading.

## Changes

- `DEFAULT_BACKUP_IMAGE` → `osodevops/kafka-backup:v0.15.12`, plus CRD doc-string regeneration (`make crdgen`, helm copies in sync)
- Changelog + version bump to 0.2.18

## Verification

- `cargo test` — 101 tests pass; `cargo clippy --all-targets -- -D warnings` clean
- `diff deploy/crds deploy/helm/.../crds` — in sync

> Draft until kafka-backup v0.15.12 is released and the image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)